### PR TITLE
fix: sanitize innerHTML and add CSP meta tags (#29)

### DIFF
--- a/.agents/workflows/bazinga.md
+++ b/.agents/workflows/bazinga.md
@@ -34,3 +34,11 @@ All new work — including work started in a bazinga-bootstrapped thread — **m
 5. Only **after approval**, you proceed with implementation on the branch.
 
 > **CAUTION:** Never skip the planning and discussion phase for anything beyond the simplest, most obvious tasks (e.g., a trivial typo fix). When in doubt, plan first.
+
+## Security Checklist
+
+When making changes that render user-supplied data (team names, cap numbers, Game #, location, etc.) into the DOM via `innerHTML`:
+
+- **Always use `escapeHTML()`** from `js/sanitize.js` to wrap user-controlled values before interpolation
+- **Never bypass** this requirement — even if the data "looks safe" (e.g., cap numbers)
+- Refer to `AGENTS.md` design decision on **innerHTML sanitization** for full details

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ wplog/
 │   ├── print.css       # Print-only B&W styles for game sheet
 │   └── standalone.css  # Shared styles for standalone pages (privacy, help)
 ├── js/
+│   ├── sanitize.js    # escapeHTML() utility — loaded first, used by sheet.js + events.js
 │   ├── config.js       # APP_VERSION + RULES definitions (USAWP, NFHS Varsity, NFHS JV)
 │   ├── confirm.js      # Custom confirmation dialog (replaces native confirm())
 │   ├── storage.js      # localStorage wrapper
@@ -52,7 +53,7 @@ wplog/
 └── lib/                # Empty (previously had vendored libs, now removed)
 ```
 
-Script load order matters: `config.js` → `confirm.js` → `storage.js` → `game.js` → `setup.js` → `events.js` → `sheet.js` → `share.js` → `app.js`
+Script load order matters: `sanitize.js` → `config.js` → `confirm.js` → `storage.js` → `game.js` → `setup.js` → `events.js` → `sheet.js` → `share.js` → `app.js`
 
 ---
 
@@ -109,6 +110,8 @@ These were explicitly discussed and agreed with the user:
 | **QR code sharing** | Single SVG (`img/qr-wplog.svg`) with white modules on transparent background. CSS `filter: invert(1)` for high-contrast overlay. Share screen always accessible. |
 | **Share tab always active** | Share tab is always enabled. Print Game Sheet button is disabled when no game is active. |
 | **Help screen** | 5th nav tab (always enabled). Full screen section with concise quick-reference guide (~1 min read). Not a footer link or overlay — too undiscoverable. |
+| **innerHTML sanitization** | All user-supplied values (team names, cap numbers, Game #, location, etc.) MUST be escaped via `escapeHTML()` from `sanitize.js` before `innerHTML` interpolation. Config-driven data (event names/codes) and internally computed values are safe but should still be escaped where mixed with user data. |
+| **CSP meta tags** | `Content-Security-Policy` and `X-Content-Type-Options` meta tags in `<head>` of `index.html`, `privacy.html`, and `help.html`. CSP uses `'unsafe-inline'` for scripts (due to inline loader) — blocks external script injection. |
 
 ### USAWP Events
 
@@ -200,6 +203,8 @@ NFHS does not have Brutality.
 - Author name in About links to `https://icemarkom.dev/`
 - Privacy link in About dialog as a row (Privacy: Policy), reordered: Version → License → Privacy → Source → Author
 - Events sorted by game time within each period (`_sortLog` in `game.js`), with scores recalculated after sort
+- HTML sanitization: `escapeHTML()` in `sanitize.js` applied to all user-controlled `innerHTML` interpolation in `sheet.js` and `events.js`
+- CSP meta tag (`Content-Security-Policy`) + `X-Content-Type-Options: nosniff` on all HTML pages (`index.html`, `privacy.html`, `help.html`)
 
 ### Known Gaps / Future Work 📋
 - No NCAA rules yet (structure ready)
@@ -244,3 +249,4 @@ Then open `http://localhost:8080`.
 12. **MAM is a dual-trigger event** — `isPersonalFoul: true` + `autoFoulOut: 2`. This pattern was explicitly designed for NFHS/NCAA.
 13. **Version system** — `APP_VERSION` lives in `config.js`. Default is `"dev"`. Deploy workflow injects release tag. Dev mode auto-detects file timestamp via `HEAD` requests. Don't hardcode versions elsewhere.
 14. **About is an overlay** — not a screen/section. It uses the same `.overlay` pattern as `ConfirmDialog` and the foul-out popup.
+15. **Always use `escapeHTML()`** — when building `innerHTML` templates with user-supplied data (team names, cap numbers, Game #, location, etc.), wrap them in `escapeHTML()`. This is mandatory — see `sanitize.js`.

--- a/help.html
+++ b/help.html
@@ -22,6 +22,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Quick Reference Guide for wplog — Water Polo Game Log">
   <meta name="theme-color" content="#0a0e1a">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <title>Help — wplog</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <meta name="description" content="Water polo game log — log events poolside, produce official game sheets">
   <meta name="theme-color" content="#0a0e1a">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <title>wplog — Water Polo Game Log</title>
   <link rel="manifest" href="manifest.json">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -180,7 +182,7 @@
 
       // Load JS files in order (dependencies first)
       const scripts = [
-        "js/config.js", "js/confirm.js", "js/storage.js", "js/game.js",
+        "js/sanitize.js", "js/config.js", "js/confirm.js", "js/storage.js", "js/game.js",
         "js/setup.js", "js/events.js", "js/sheet.js", "js/share.js", "js/app.js",
       ];
       for (const src of scripts) {

--- a/js/events.js
+++ b/js/events.js
@@ -473,7 +473,7 @@ const Events = {
                 row.innerHTML = `
           <span class="log-time">${entry.period === "SO" ? "" : entry.time.replace(/^0(\d:)/, '$1')}</span>
           <span class="log-team ${entry.team === 'W' ? 'team-white' : 'team-dark'}">${entry.team}</span>
-          <span class="log-cap">${entry.cap}</span>
+          <span class="log-cap">${escapeHTML(entry.cap)}</span>
           <span class="log-event event-${this._getEventClass(entry.event)}">${eventName}</span>
           <span class="log-score">${Game.formatEntryScore(entry, this.game)}</span>
           <button class="log-delete-btn" data-id="${entry.id}" title="Delete">✕</button>

--- a/js/sanitize.js
+++ b/js/sanitize.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2026 Marko Milivojevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// wplog — HTML Sanitization Utility
+// Escapes user-supplied strings before interpolation into innerHTML templates.
+
+function escapeHTML(str) {
+    return String(str).replace(/[&<>"']/g,
+        c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}

--- a/js/sheet.js
+++ b/js/sheet.js
@@ -60,26 +60,26 @@ const Sheet = {
       <div class="sheet-title">Game Sheet</div>
       <div class="sheet-meta">
         <div class="sheet-meta-row">
-          <span class="sheet-meta-pair"><span class="sheet-label">Game #:</span> <span class="sheet-value">${game.gameId || "—"}</span></span>
+          <span class="sheet-meta-pair"><span class="sheet-label">Game #:</span> <span class="sheet-value">${escapeHTML(game.gameId || "—")}</span></span>
         </div>
         <div class="sheet-meta-row">
-          <span class="sheet-meta-pair"><span class="sheet-label">Location:</span> <span class="sheet-value">${game.location || "—"}</span></span>
+          <span class="sheet-meta-pair"><span class="sheet-label">Location:</span> <span class="sheet-value">${escapeHTML(game.location || "—")}</span></span>
         </div>
         <div class="sheet-meta-row sheet-meta-times">
-          <span class="sheet-meta-pair"><span class="sheet-label">Date:</span> <span class="sheet-value">${game.date}</span></span>
-          <span class="sheet-meta-pair"><span class="sheet-label">Scheduled:</span> <span class="sheet-value">${game.startTime || "--:--"}</span></span>
-          <span class="sheet-meta-pair"><span class="sheet-label">Ended:</span> <span class="sheet-value">${game.endTime || "--:--"}</span></span>
+          <span class="sheet-meta-pair"><span class="sheet-label">Date:</span> <span class="sheet-value">${escapeHTML(game.date)}</span></span>
+          <span class="sheet-meta-pair"><span class="sheet-label">Scheduled:</span> <span class="sheet-value">${escapeHTML(game.startTime || "--:--")}</span></span>
+          <span class="sheet-meta-pair"><span class="sheet-label">Ended:</span> <span class="sheet-value">${escapeHTML(game.endTime || "--:--")}</span></span>
         </div>
       </div>
       <div class="sheet-teams">
         <div class="sheet-team sheet-team-white">
           <span class="sheet-team-label">White</span>
-          <span class="sheet-team-name">${whiteName}</span>
+          <span class="sheet-team-name">${escapeHTML(whiteName)}</span>
         </div>
-        <div class="sheet-final-score">${score.white} — ${score.dark}</div>
+        <div class="sheet-final-score">${escapeHTML(score.white)} — ${escapeHTML(score.dark)}</div>
         <div class="sheet-team sheet-team-dark">
           <span class="sheet-team-label">Dark</span>
-          <span class="sheet-team-name">${darkName}</span>
+          <span class="sheet-team-name">${escapeHTML(darkName)}</span>
         </div>
       </div>
     `;
@@ -125,11 +125,11 @@ const Sheet = {
                 const eventDef = rules.events.find((e) => e.code === entry.event);
                 const align = eventDef && eventDef.align ? eventDef.align : "center";
                 tr.innerHTML = `
-          <td>${entry.period === "SO" ? "" : entry.time.replace(/^0(\d:)/, '$1')}</td>
-          <td>${entry.cap || "—"}</td>
-          <td>${entry.team || "—"}</td>
-          <td style="text-align:${align}">${entry.event}</td>
-          <td>${Game.formatEntryScore(entry, this.game)}</td>
+          <td>${entry.period === "SO" ? "" : escapeHTML(entry.time.replace(/^0(\d:)/, '$1'))}</td>
+          <td>${escapeHTML(entry.cap || "—")}</td>
+          <td>${escapeHTML(entry.team || "—")}</td>
+          <td style="text-align:${align}">${escapeHTML(entry.event)}</td>
+          <td>${escapeHTML(Game.formatEntryScore(entry, this.game))}</td>
         `;
             }
             tbody.appendChild(tr);
@@ -256,9 +256,9 @@ const Sheet = {
 
             tr.innerHTML = `
         <td>${player.team === "W" ? "White" : "Dark"}</td>
-        <td>${player.cap}</td>
+        <td>${escapeHTML(player.cap)}</td>
         <td>${player.fouls.length}</td>
-        <td class="sheet-foul-details">${details}</td>
+        <td class="sheet-foul-details">${escapeHTML(details)}</td>
       `;
             tbody.appendChild(tr);
         }
@@ -344,10 +344,10 @@ const Sheet = {
             const eventDef = rules.events.find((e) => e.code === entry.event);
             tr.innerHTML = `
         <td>${entry.team === "W" ? "White" : (entry.team === "D" ? "Dark" : "—")}</td>
-        <td>${entry.cap || "—"}</td>
+        <td>${escapeHTML(entry.cap || "—")}</td>
         <td>${Game.getPeriodLabel(entry.period)}</td>
-        <td>${entry.time.replace(/^0(\d:)/, '$1')}</td>
-        <td>${eventDef ? eventDef.name : entry.event}</td>
+        <td>${escapeHTML(entry.time.replace(/^0(\d:)/, '$1'))}</td>
+        <td>${eventDef ? eventDef.name : escapeHTML(entry.event)}</td>
       `;
             tbody.appendChild(tr);
         }

--- a/privacy.html
+++ b/privacy.html
@@ -22,6 +22,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Privacy Policy for wplog — Water Polo Game Log">
   <meta name="theme-color" content="#0a0e1a">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
+  <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <title>Privacy Policy — wplog</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/sw.js
+++ b/sw.js
@@ -25,6 +25,7 @@ const ASSETS = [
     "./css/style.css",
     "./css/print.css",
     "./css/standalone.css",
+    "./js/sanitize.js",
     "./js/config.js",
     "./js/confirm.js",
     "./js/storage.js",


### PR DESCRIPTION
- Add js/sanitize.js with escapeHTML() utility
- Apply escapeHTML() to all user-controlled innerHTML in sheet.js and events.js
- Add Content-Security-Policy and X-Content-Type-Options meta tags to index.html, privacy.html, help.html
- Add sanitize.js to script load order and SW cache
- Update AGENTS.md with sanitization design decisions and agent notes
- Add Security Checklist to bazinga workflow
