### PR TITLE
fix: externalize inline scripts, add localStorage validation and Referrer-Policy (#29)

### DIFF
--- a/help.html
+++ b/help.html
@@ -22,8 +22,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Quick Reference Guide for wplog — Water Polo Game Log">
   <meta name="theme-color" content="#0a0e1a">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
   <title>Help — wplog</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -121,10 +122,11 @@
 
     <div class="footer">
       Copyright &copy;
-      <script>document.write(new Date().getFullYear())</script> Marko Milivojevic &middot;
+      <span id="year"></span> Marko Milivojevic &middot;
       <a href="https://github.com/icemarkom/wplog" target="_blank" rel="noopener">wplog</a>
     </div>
   </div>
+  <script src="js/year.js" defer></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -22,8 +22,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <meta name="description" content="Water polo game log — log events poolside, produce official game sheets">
   <meta name="theme-color" content="#0a0e1a">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
   <title>wplog — Water Polo Game Log</title>
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="img/favicon-32.png" type="image/png" sizes="32x32">
@@ -165,42 +166,10 @@
     <span id="app-version"></span> &middot;
     <a href="#" id="footer-about-link">About</a>
   </footer>
-  <script>document.getElementById("copy-year").textContent = new Date().getFullYear();</script>
+  <script src="js/year.js" defer></script>
 
   <!-- Screen Loader + Scripts -->
-  <script>
-    (async function () {
-      const screens = [
-        { url: "screens/setup.html", target: "setup-content" },
-        { url: "screens/live.html", target: "live-content" },
-        { url: "screens/modal.html", target: "modal-content" },
-        { url: "screens/sheet.html", target: "sheet-container" },
-        { url: "screens/share.html", target: "share-content" },
-      ];
-      await Promise.all(screens.map(async ({ url, target }) => {
-        const res = await fetch(url);
-        document.getElementById(target).innerHTML = await res.text();
-      }));
-
-      // Load JS files in order (dependencies first)
-      const scripts = [
-        "js/sanitize.js", "js/config.js", "js/confirm.js", "js/storage.js", "js/game.js",
-        "js/setup.js", "js/events.js", "js/sheet.js", "js/share.js", "js/app.js",
-      ];
-      for (const src of scripts) {
-        await new Promise((resolve, reject) => {
-          const s = document.createElement("script");
-          s.src = src;
-          s.onload = resolve;
-          s.onerror = reject;
-          document.body.appendChild(s);
-        });
-      }
-
-      // DOMContentLoaded already fired, so manually init the app
-      App.init();
-    })();
-  </script>
+  <script src="js/loader.js"></script>
 </body>
 
 </html>

--- a/js/loader.js
+++ b/js/loader.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2026 Marko Milivojevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// wplog — App Shell Loader
+// Loads screen fragments and JS dependencies, then initializes the app.
+
+(async function () {
+    const screens = [
+        { url: "screens/setup.html", target: "setup-content" },
+        { url: "screens/live.html", target: "live-content" },
+        { url: "screens/modal.html", target: "modal-content" },
+        { url: "screens/sheet.html", target: "sheet-container" },
+        { url: "screens/share.html", target: "share-content" },
+    ];
+    await Promise.all(screens.map(async ({ url, target }) => {
+        const res = await fetch(url);
+        document.getElementById(target).innerHTML = await res.text();
+    }));
+
+    // Load JS files in order (dependencies first)
+    const scripts = [
+        "js/sanitize.js", "js/config.js", "js/confirm.js", "js/storage.js", "js/game.js",
+        "js/setup.js", "js/events.js", "js/sheet.js", "js/share.js", "js/app.js",
+    ];
+    for (const src of scripts) {
+        await new Promise((resolve, reject) => {
+            const s = document.createElement("script");
+            s.src = src;
+            s.onload = resolve;
+            s.onerror = reject;
+            document.body.appendChild(s);
+        });
+    }
+
+    // DOMContentLoaded already fired, so manually init the app
+    App.init();
+})();

--- a/js/storage.js
+++ b/js/storage.js
@@ -30,7 +30,13 @@ const Storage = {
     load() {
         try {
             const data = localStorage.getItem(this.KEY);
-            return data ? JSON.parse(data) : null;
+            if (!data) return null;
+            const game = JSON.parse(data);
+            if (!game || typeof game.rules !== "string" || !Array.isArray(game.log)) {
+                console.warn("Invalid game data in localStorage, ignoring.");
+                return null;
+            }
+            return game;
         } catch (e) {
             console.error("Failed to load game:", e);
             return null;

--- a/js/year.js
+++ b/js/year.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2026 Marko Milivojevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// wplog — Copyright Year Display
+// Sets the copyright year in elements with id="year" or id="copy-year".
+
+(function () {
+    var el = document.getElementById("copy-year") || document.getElementById("year");
+    if (el) el.textContent = new Date().getFullYear();
+})();

--- a/privacy.html
+++ b/privacy.html
@@ -22,8 +22,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Privacy Policy for wplog — Water Polo Game Log">
   <meta name="theme-color" content="#0a0e1a">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
   <title>Privacy Policy — wplog</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -103,10 +104,11 @@
 
     <div class="footer">
       Copyright &copy;
-      <script>document.write(new Date().getFullYear())</script> Marko Milivojevic &middot;
+      <span id="year"></span> Marko Milivojevic &middot;
       <a href="https://github.com/icemarkom/wplog" target="_blank" rel="noopener">wplog</a>
     </div>
   </div>
+  <script src="js/year.js" defer></script>
 </body>
 
 </html>

--- a/sw.js
+++ b/sw.js
@@ -26,6 +26,8 @@ const ASSETS = [
     "./css/print.css",
     "./css/standalone.css",
     "./js/sanitize.js",
+    "./js/loader.js",
+    "./js/year.js",
     "./js/config.js",
     "./js/confirm.js",
     "./js/storage.js",


### PR DESCRIPTION
- Move index.html inline loader to js/loader.js
- Move inline copyright year to js/year.js (shared by all pages)
- Tighten CSP: remove 'unsafe-inline' from script-src on all pages
- Add Referrer-Policy meta tag to all HTML pages
- Add localStorage schema validation in Storage.load()
- Add loader.js and year.js to SW cache
