### PR TITLE
Refactor rules config: inheritance, STATS_EVENTS, addEvents/removeEvents, cap flags (#50)

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -19,130 +19,169 @@
 const APP_VERSION = "dev";
 
 // wplog — Rules Configuration
-// USAWP only for now. Structure supports future NFHS/NCAA additions.
 //
 // Each event has:
 //   name       — display name
 //   code       — (optional) internal code stored in the log; defaults to name if omitted
-//   color      — CSS color class: "green", "amber", "orange", "blue", "yellow", "red"
+//   color      — CSS color class: "green", "amber", "orange", "blue", "yellow", "red", "teal"
 //   align      — (optional) sheet Code column alignment: "left", "right", "center" (default: "center")
-//   noPlayer   — (optional) true if event has no player (e.g. timeout)
-//   autoFoulOut — (optional) 1 = immediate ejection, 2 = after 2nd occurrence
+//   noPlayer      — (optional) true if event has no player (e.g. timeout)
+//   autoFoulOut   — (optional) 1 = immediate ejection, 2 = after 2nd occurrence
+//   isPersonalFoul — (optional) true if event counts toward personal foul limit
+//   statsOnly     — (optional) true if event is for stats tracking only
+//   allowCoach    — (optional) true to allow "C" (coach) as cap value
+//   allowAssistant — (optional) true to allow "AC" (assistant coach) as cap value
+//   allowBench    — (optional) true to allow "B" (bench) as cap value
+//   allowNoCap    — (optional) true to allow submitting without a cap number
 //
-// Events are listed in order of typical game frequency (most frequent first).
+// Rule sets support inheritance via the `inherits` key:
+//   inherits     — (optional) key of parent rule set; child overrides only what differs
+//   addEvents    — (optional) array of { before|after: "CODE", event: {...} } insertion directives
+//   removeEvents — (optional) array of event codes to remove from inherited events
+//
+// Rule set keys starting with _ are internal (hidden from setup dropdown).
+//
+// Stats events are defined once in STATS_EVENTS and auto-appended to all rule sets.
+
+const STATS_EVENTS = [
+    { name: "Shot", color: "teal", statsOnly: true },
+    { name: "Assist", color: "teal", statsOnly: true },
+    { name: "Steal", color: "teal", statsOnly: true },
+    { name: "Intercept", color: "teal", statsOnly: true },
+    { name: "Turnover", color: "teal", statsOnly: true },
+    { name: "Field Block", color: "teal", statsOnly: true },
+    { name: "Save", color: "teal", statsOnly: true },
+    { name: "Drawn Exclusion", color: "teal", statsOnly: true },
+    { name: "Drawn Penalty", color: "teal", statsOnly: true },
+    { name: "Sprint Won", color: "teal", statsOnly: true },
+];
 
 const RULES = {
-  USAWP: {
-    name: "USA Water Polo",
-    periods: 4,
-    periodLength: 8,       // quarter length in minutes (3-9)
-    otPeriodLength: null,   // no OT by default; 3 min when enabled
-    overtime: false,
-    shootout: true,
-    events: [
-      { name: "Goal", code: "G", color: "green", align: "left" },
-      { name: "Exclusion", code: "E", color: "amber", align: "right", isPersonalFoul: true },
-      { name: "Penalty", code: "P", color: "amber", align: "right", isPersonalFoul: true },
-      { name: "Timeout", code: "TO", color: "blue", noPlayer: true, align: "center" },
-      { name: "Timeout 30", code: "TO30", color: "blue", align: "center", noPlayer: true },
-      { name: "Yellow Card", code: "YC", color: "yellow", align: "center" },
-      { name: "Penalty-Exclusion", code: "P-E", color: "amber", align: "right", isPersonalFoul: true },
-      { name: "Misconduct", code: "MC", color: "red", align: "right", autoFoulOut: 1 },
-      { name: "Brutality", code: "BR", color: "red", align: "right", autoFoulOut: 1 },
-      { name: "Red Card", code: "RC", color: "red", align: "center" },
-      { name: "Game Exclusion", code: "E-Game", color: "red", align: "right", autoFoulOut: 1 },
-      // Stats-only events (code auto-derived from name)
-      { name: "Shot", color: "teal", statsOnly: true },
-      { name: "Assist", color: "teal", statsOnly: true },
-      { name: "Steal", color: "teal", statsOnly: true },
-      { name: "Intercept", color: "teal", statsOnly: true },
-      { name: "Turnover", color: "teal", statsOnly: true },
-      { name: "Field Block", color: "teal", statsOnly: true },
-      { name: "Save", color: "teal", statsOnly: true },
-      { name: "Drawn Exclusion", color: "teal", statsOnly: true },
-      { name: "Drawn Penalty", color: "teal", statsOnly: true },
-      { name: "Sprint Won", color: "teal", statsOnly: true },
-    ],
-    foulOutLimit: 3,
-    timeouts: { full: 2, to30: 0 },
-  },
-  NFHSVA: {
-    name: "NFHS Varsity",
-    periods: 4,
-    periodLength: 7,
-    otPeriodLength: 3,
-    overtime: true,
-    shootout: false,
-    events: [
-      { name: "Goal", code: "G", color: "green", align: "left" },
-      { name: "Exclusion", code: "E", color: "amber", align: "right", isPersonalFoul: true },
-      { name: "Penalty", code: "P", color: "amber", align: "right", isPersonalFoul: true },
-      { name: "Minor Act", code: "MAM", color: "amber", align: "right", isPersonalFoul: true, autoFoulOut: 2 },
-      { name: "Penalty-Exclusion", code: "P-E", color: "amber", align: "right", isPersonalFoul: true },
-      { name: "Yellow Card", code: "YC", color: "yellow", align: "center" },
-      { name: "Timeout", code: "TO", color: "blue", noPlayer: true, align: "center" },
-      { name: "Timeout 30", code: "TO30", color: "blue", align: "center", noPlayer: true },
-      { name: "Misconduct", code: "MC", color: "red", align: "right", autoFoulOut: 1 },
-      { name: "Game Exclusion", code: "E-Game", color: "red", align: "right", autoFoulOut: 1 },
-      { name: "Flagrant Misconduct", code: "FM", color: "red", align: "right", autoFoulOut: 1 },
-      { name: "Red Card", code: "RC", color: "red", align: "center" },
-      // Stats-only events (code auto-derived from name)
-      { name: "Shot", color: "teal", statsOnly: true },
-      { name: "Assist", color: "teal", statsOnly: true },
-      { name: "Steal", color: "teal", statsOnly: true },
-      { name: "Intercept", color: "teal", statsOnly: true },
-      { name: "Turnover", color: "teal", statsOnly: true },
-      { name: "Field Block", color: "teal", statsOnly: true },
-      { name: "Save", color: "teal", statsOnly: true },
-      { name: "Drawn Exclusion", color: "teal", statsOnly: true },
-      { name: "Drawn Penalty", color: "teal", statsOnly: true },
-      { name: "Sprint Won", color: "teal", statsOnly: true },
-    ],
-    foulOutLimit: 3,
-    timeouts: { full: 3, to30: 1 },
-  },
-  NFHSJV: {
-    name: "NFHS Junior Varsity",
-    periods: 4,
-    periodLength: 6,
-    otPeriodLength: 0,
-    overtime: false,
-    shootout: false,
-    events: [
-      { name: "Goal", code: "G", color: "green", align: "left" },
-      { name: "Exclusion", code: "E", color: "amber", align: "right", isPersonalFoul: true },
-      { name: "Penalty", code: "P", color: "amber", align: "right", isPersonalFoul: true },
-      { name: "Minor Act", code: "MAM", color: "amber", align: "right", isPersonalFoul: true, autoFoulOut: 2 },
-      { name: "Penalty-Exclusion", code: "P-E", color: "amber", align: "right", isPersonalFoul: true },
-      { name: "Yellow Card", code: "YC", color: "yellow", align: "center" },
-      { name: "Timeout", code: "TO", color: "blue", noPlayer: true, align: "center" },
-      { name: "Timeout 30", code: "TO30", color: "blue", align: "center", noPlayer: true },
-      { name: "Misconduct", code: "MC", color: "red", align: "right", autoFoulOut: 1 },
-      { name: "Game Exclusion", code: "E-Game", color: "red", align: "right", autoFoulOut: 1 },
-      { name: "Flagrant Misconduct", code: "FM", color: "red", align: "right", autoFoulOut: 1 },
-      { name: "Red Card", code: "RC", color: "red", align: "center" },
-      // Stats-only events (code auto-derived from name)
-      { name: "Shot", color: "teal", statsOnly: true },
-      { name: "Assist", color: "teal", statsOnly: true },
-      { name: "Steal", color: "teal", statsOnly: true },
-      { name: "Intercept", color: "teal", statsOnly: true },
-      { name: "Turnover", color: "teal", statsOnly: true },
-      { name: "Field Block", color: "teal", statsOnly: true },
-      { name: "Save", color: "teal", statsOnly: true },
-      { name: "Drawn Exclusion", color: "teal", statsOnly: true },
-      { name: "Drawn Penalty", color: "teal", statsOnly: true },
-      { name: "Sprint Won", color: "teal", statsOnly: true },
-    ],
-    foulOutLimit: 3,
-    timeouts: { full: 3, to30: 1 },
-  },
+    _base: { // this is a hidden rule; all rules starting with _ are hidden from the ui. think of them as templates.
+        periods: 4,
+        foulOutLimit: 3,
+    },
+    USAWP: {
+        inherits: "_base",
+        name: "USA Water Polo",
+        periodLength: 8,
+        overtime: false,
+        shootout: true,
+        events: [
+            { name: "Goal", code: "G", color: "green", align: "left" },
+            { name: "Exclusion", code: "E", color: "amber", align: "right", isPersonalFoul: true },
+            { name: "Penalty", code: "P", color: "amber", align: "right", isPersonalFoul: true },
+            { name: "Timeout", code: "TO", color: "blue", noPlayer: true, align: "center" },
+            { name: "Timeout 30", code: "TO30", color: "blue", align: "center", noPlayer: true },
+            { name: "Yellow Card", code: "YC", color: "yellow", align: "center", allowCoach: true, allowAssistant: false, allowBench: true },
+            { name: "Penalty-Exclusion", code: "P-E", color: "amber", align: "right", isPersonalFoul: true },
+            { name: "Misconduct", code: "MC", color: "red", align: "right", autoFoulOut: 1 },
+            { name: "Brutality", code: "BR", color: "red", align: "right", autoFoulOut: 1 },
+            { name: "Red Card", code: "RC", color: "red", align: "center", allowCoach: true, allowAssistant: true },
+            { name: "Game Exclusion", code: "E-Game", color: "red", align: "right", autoFoulOut: 1 },
+        ],
+        timeouts: { full: 2, to30: 0 },
+    },
+    _academic: {
+        inherits: "_base",
+        periodLength: 7,
+        otPeriodLength: 3,
+        overtime: true,
+        shootout: false,
+        events: [
+            { name: "Goal", code: "G", color: "green", align: "left" },
+            { name: "Exclusion", code: "E", color: "amber", align: "right", isPersonalFoul: true },
+            { name: "Penalty", code: "P", color: "amber", align: "right", isPersonalFoul: true },
+            { name: "Minor Act", code: "MAM", color: "amber", align: "right", isPersonalFoul: true, autoFoulOut: 2 },
+            { name: "Penalty-Exclusion", code: "P-E", color: "amber", align: "right", isPersonalFoul: true },
+            { name: "Yellow Card", code: "YC", color: "yellow", align: "center", allowCoach: true, allowAssistant: false, allowBench: true },
+            { name: "Timeout", code: "TO", color: "blue", noPlayer: true, align: "center" },
+            { name: "Timeout 30", code: "TO30", color: "blue", align: "center", noPlayer: true },
+            { name: "Misconduct", code: "MC", color: "red", align: "right", autoFoulOut: 1 },
+            { name: "Game Exclusion", code: "E-Game", color: "red", align: "right", autoFoulOut: 1 },
+            { name: "Flagrant Misconduct", code: "FM", color: "red", align: "right", autoFoulOut: 1 },
+            { name: "Red Card", code: "RC", color: "red", align: "center", allowCoach: true, allowAssistant: true },
+        ],
+        timeouts: { full: 3, to30: 1 },
+    },
+    NFHSVA: {
+        inherits: "_academic",
+        name: "NFHS Varsity",
+    },
+    NFHSJV: {
+        inherits: "_academic",
+        name: "NFHS Junior Varsity",
+        periodLength: 6,
+        overtime: false,
+    },
+    NCAA: {
+        inherits: "_academic",
+        name: "NCAA",
+        periodLength: 8,
+        addEvents: [
+            { before: "RC", event: { name: "Yellow/Red Card", code: "YRC", color: "yellow", align: "right", allowCoach: true, allowAssistant: false } },
+        ],
+    },
 };
 
-// Auto-derive code from name for any event that doesn't specify one
-for (const ruleSet of Object.values(RULES)) {
-  for (const evt of ruleSet.events) {
-    if (!evt.code) {
-      evt.code = evt.name;
-    }
-  }
+// --- Inheritance Resolver ---
+
+function _deepCopy(obj) {
+    return JSON.parse(JSON.stringify(obj));
 }
+
+function _resolveRules() {
+    // 1. Detect circular inheritance chains
+    for (const key of Object.keys(RULES)) {
+        const seen = new Set();
+        let cur = key;
+        while (RULES[cur]?.inherits) {
+            if (seen.has(cur)) {
+                throw new Error("Circular inheritance: " + [...seen, cur].join(" \u2192 "));
+            }
+            seen.add(cur);
+            cur = RULES[cur].inherits;
+        }
+    }
+    // 2. Resolve in dependency order (parents first)
+    const resolved = new Set();
+    function resolve(key) {
+        if (resolved.has(key)) return;
+        const rule = RULES[key];
+        if (rule.inherits) {
+            resolve(rule.inherits);
+            RULES[key] = { ..._deepCopy(RULES[rule.inherits]), ...rule };
+            delete RULES[key].inherits;
+        }
+        resolved.add(key);
+    }
+    for (const key of Object.keys(RULES)) resolve(key);
+    // 3. Apply removeEvents / addEvents directives
+    for (const [key, rule] of Object.entries(RULES)) {
+        if (rule.removeEvents) {
+            rule.events = (rule.events || []).filter(e => !rule.removeEvents.includes(e.code));
+            delete rule.removeEvents;
+        }
+        if (rule.addEvents) {
+            for (const directive of rule.addEvents) {
+                const anchorCode = directive.after || directive.before;
+                const idx = (rule.events || []).findIndex(e => e.code === anchorCode);
+                if (idx === -1) throw new Error(key + ": addEvents anchor '" + anchorCode + "' not found");
+                const pos = directive.after ? idx + 1 : idx;
+                rule.events.splice(pos, 0, directive.event);
+            }
+            delete rule.addEvents;
+        }
+    }
+    // 4. Append STATS_EVENTS to every rule set
+    for (const rule of Object.values(RULES)) {
+        rule.events = [...(rule.events || []), ...STATS_EVENTS];
+    }
+    // 5. Auto-derive code from name for any event missing one
+    for (const rule of Object.values(RULES)) {
+        for (const evt of rule.events) {
+            if (!evt.code) evt.code = evt.name;
+        }
+    }
+}
+_resolveRules();

--- a/js/events.js
+++ b/js/events.js
@@ -146,15 +146,18 @@ const Events = {
                 this._capRaw = this._capRaw.slice(0, -1);
             } else if (["A", "B", "C"].includes(val)) {
                 const code = document.getElementById("modal-event-title").dataset.code;
-                const isCard = (code === "YC" || code === "RC");
-                if (isCard) {
-                    // Cards: allow "C" (coach), "A" then "C" → "AC" (asst coach)
-                    if (val === "C" && this._capRaw === "") {
+                const rules = RULES[this.game.rules];
+                const eventDef = rules.events.find((e) => e.code === code);
+                if (eventDef && (eventDef.allowCoach || eventDef.allowAssistant || eventDef.allowBench)) {
+                    // Coach/assistant/bench: "C" = coach, "A" then "C" → "AC" = asst coach, "B" = bench
+                    if (val === "C" && eventDef.allowCoach && this._capRaw === "") {
                         this._capRaw = "C";
-                    } else if (val === "C" && this._capRaw === "A") {
+                    } else if (val === "C" && eventDef.allowAssistant && this._capRaw === "A") {
                         this._capRaw = "AC";
-                    } else if (val === "A" && this._capRaw === "") {
+                    } else if (val === "A" && eventDef.allowAssistant && this._capRaw === "") {
                         this._capRaw = "A";
+                    } else if (val === "B" && eventDef.allowBench && this._capRaw === "") {
+                        this._capRaw = "B";
                     }
                 } else {
                     // Normal: A/B/C only after "1" (goalie numbers)

--- a/js/setup.js
+++ b/js/setup.js
@@ -157,6 +157,7 @@ const Setup = {
         const select = document.getElementById("setup-rules");
         select.innerHTML = "";
         for (const [key, rules] of Object.entries(RULES)) {
+            if (key.startsWith("_")) continue;
             const opt = document.createElement("option");
             opt.value = key;
             opt.textContent = rules.name;


### PR DESCRIPTION
- Add inherits keyword with multi-level chain support and loop detection
- Extract STATS_EVENTS constant (10 events defined once, auto-appended)
- Add _base and _academic template rule sets (underscore prefix = hidden)
- Add addEvents (positioned insertion) and removeEvents directives
- Add config-driven allowCoach, allowAssistant, allowBench, allowNoCap flags
- Replace hardcoded event code checks in events.js with flag lookups
- Add NCAA rule set using addEvents for Yellow/Red Card
- Simplify NFHSJV to 4-line override via inheritance
