### PR TITLE
Add allowPlayer flag for non-player events (#50)

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -32,6 +32,7 @@ const APP_VERSION = "dev";
 //   allowCoach    — (optional) true to allow "C" (coach) as cap value
 //   allowAssistant — (optional) true to allow "AC" (assistant coach) as cap value
 //   allowBench    — (optional) true to allow "B" (bench) as cap value
+//   allowPlayer   — (optional, default: true) false to block digit cap input (non-player events)
 //   allowNoCap    — (optional) true to allow submitting without a cap number
 //
 // Rule sets support inheritance via the `inherits` key:
@@ -119,7 +120,7 @@ const RULES = {
         name: "NCAA",
         periodLength: 8,
         addEvents: [
-            { before: "RC", event: { name: "Yellow/Red Card", code: "YRC", color: "yellow", align: "right", allowCoach: true, allowAssistant: false } },
+            { before: "RC", event: { name: "Yellow/Red Card", code: "YRC", color: "yellow", align: "right", allowPlayer: false, allowCoach: true, allowAssistant: false } },
         ],
     },
 };

--- a/js/events.js
+++ b/js/events.js
@@ -166,7 +166,13 @@ const Events = {
                     }
                 }
             } else {
-                if (this._capRaw.length < 2 && !this._capRaw.match(/[ABC]/)) {
+                // Digit input — blocked when allowPlayer is false
+                const code = document.getElementById("modal-event-title").dataset.code;
+                const rules = RULES[this.game.rules];
+                const eventDef = rules.events.find((e) => e.code === code);
+                if (eventDef && eventDef.allowPlayer === false) {
+                    // No digit input for non-player events
+                } else if (this._capRaw.length < 2 && !this._capRaw.match(/[ABC]/)) {
                     this._capRaw += val;
                 }
             }


### PR DESCRIPTION
- allowPlayer (default: true) blocks digit cap input when false
- Only special values (C, AC, B) accepted for non-player events
- Needed for events like NCAA Yellow/Red Card (coach-only)
