### PR TITLE
fix: respect statsTimeMode for all events in stats-only mode (#56)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,11 +276,10 @@ Inherits from `_academic` (8-min periods). Adds:
 ## How to Run
 
 Serve locally with any static file server. The app has no build step.
+Do NOT use Python's `http.server` — use Go's stdlib file server:
 
 ```sh
-python3 -m http.server 8080
-# or
-npx serve
+go run <(echo 'package main; import "net/http"; func main() { http.ListenAndServe(":8080", http.FileServer(http.Dir("."))) }')
 ```
 
 Then open `http://localhost:8080`.

--- a/js/events.js
+++ b/js/events.js
@@ -198,11 +198,12 @@ const Events = {
         const code = document.getElementById("modal-event-title").dataset.code;
         const rules = RULES[this.game.rules];
         const eventDef = rules.events.find((e) => e.code === code);
+        const isStatsMode = !this.game.enableLog && this.game.enableStats;
         const isStatsOnly = eventDef && eventDef.statsOnly;
         const timeMode = this.game.statsTimeMode || "off";
 
         let hasTime;
-        if (isStatsOnly && (timeMode === "off" || timeMode === "optional")) {
+        if ((isStatsOnly || isStatsMode) && (timeMode === "off" || timeMode === "optional")) {
             hasTime = true; // time not required
         } else {
             hasTime = this._timeRaw.length > 0 && this._parseTime(this._timeRaw) !== null;
@@ -283,14 +284,15 @@ const Events = {
 
         // Default target: cap for SO (time is locked), time otherwise
         // Stats events: adjust for statsTimeMode
+        const isStatsMode = !this.game.enableLog && this.game.enableStats;
         const isStatsOnly = eventDef.statsOnly;
         const timeMode = this.game.statsTimeMode || "off";
 
-        if (isStatsOnly && timeMode === "off") {
+        if ((isStatsOnly || isStatsMode) && timeMode === "off") {
             // Hide time field entirely
             timeField.style.display = "none";
             this._setNumpadTarget(eventDef.teamOnly ? "time" : "cap");
-        } else if (isStatsOnly && timeMode === "optional") {
+        } else if ((isStatsOnly || isStatsMode) && timeMode === "optional") {
             timeField.style.display = "";
             this._setNumpadTarget(eventDef.teamOnly ? "time" : "cap");
         } else {
@@ -328,11 +330,12 @@ const Events = {
         if (!eventDef) return;
 
         // Parse time (stats events may have no time)
+        const isStatsMode = !this.game.enableLog && this.game.enableStats;
         const isStatsOnly = eventDef.statsOnly;
         const timeMode = this.game.statsTimeMode || "off";
         let time;
 
-        if (isStatsOnly && (timeMode === "off" || (timeMode === "optional" && this._timeRaw.length === 0))) {
+        if ((isStatsOnly || isStatsMode) && (timeMode === "off" || (timeMode === "optional" && this._timeRaw.length === 0))) {
             time = "";
         } else {
             const parsed = this._parseTime(this._timeRaw);


### PR DESCRIPTION
In stats-only mode, non-statsOnly events (Goal, Exclusion, etc.) still
required time entry even when statsTimeMode was 'off'. Added isStatsMode
check alongside isStatsOnly in _updateOkButton, _openModal, and
_confirmEvent.

Also update AGENTS.md How to Run section to use Go file server.
