### PR TITLE
fix: add keyboard input support to event modal (#57)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,10 +276,10 @@ Inherits from `_academic` (8-min periods). Adds:
 ## How to Run
 
 Serve locally with any static file server. The app has no build step.
-Do NOT use Python's `http.server` — use Go's stdlib file server:
+Do NOT use Python's `http.server` — use the included `serve.go`:
 
 ```sh
-go run <(echo 'package main; import "net/http"; func main() { http.ListenAndServe(":8080", http.FileServer(http.Dir("."))) }')
+go run serve.go
 ```
 
 Then open `http://localhost:8080`.

--- a/js/events.js
+++ b/js/events.js
@@ -123,6 +123,72 @@ const Events = {
 
         // OK
         document.getElementById("event-modal-confirm").addEventListener("click", () => this._confirmEvent());
+
+        // Keyboard input — desktop support
+        document.addEventListener("keydown", (e) => {
+            if (!document.getElementById("event-modal").classList.contains("visible")) return;
+
+            const key = e.key;
+
+            // Digits 0-9
+            if (key >= "0" && key <= "9") {
+                e.preventDefault();
+                this._handleNumpad(key);
+                return;
+            }
+
+            // Letters A/B/C (case-insensitive)
+            const upper = key.toUpperCase();
+            if (["A", "B", "C"].includes(upper)) {
+                e.preventDefault();
+                this._handleNumpad(upper);
+                return;
+            }
+
+            // W/D for team selection (case-insensitive)
+            if (upper === "W") {
+                e.preventDefault();
+                this._selectTeam("W");
+                return;
+            }
+            if (upper === "D") {
+                e.preventDefault();
+                this._selectTeam("D");
+                return;
+            }
+
+            // Backspace = clear
+            if (key === "Backspace") {
+                e.preventDefault();
+                this._handleNumpad("clear");
+                return;
+            }
+
+            // Tab = toggle time/cap field
+            if (key === "Tab") {
+                e.preventDefault();
+                const next = this._numpadTarget === "time" ? "cap" : "time";
+                this._setNumpadTarget(next, true);
+                return;
+            }
+
+            // Enter = confirm (if OK is enabled)
+            if (key === "Enter") {
+                e.preventDefault();
+                const okBtn = document.getElementById("event-modal-confirm");
+                if (!okBtn.disabled) {
+                    this._confirmEvent();
+                }
+                return;
+            }
+
+            // Escape = cancel
+            if (key === "Escape") {
+                e.preventDefault();
+                this._closeModal();
+                return;
+            }
+        });
     },
 
     _handleNumpad(val) {


### PR DESCRIPTION
Physical keyboard now works in the event modal on desktop:
- Digits 0-9 and letters A/B/C feed the numpad
- W/D select team (case-insensitive)
- Backspace clears last digit
- Tab toggles between time and cap fields
- Enter submits (when OK is enabled)
- Escape cancels

Also update AGENTS.md How to Run to reference serve.go.
