### PR TITLE
fix: remove screen switch from print flow (#67)

### DIFF
--- a/js/share.js
+++ b/js/share.js
@@ -34,9 +34,10 @@ const Share = {
 
     printSheet() {
         if (!this.game) return;
-        // Navigate to sheet view and print
-        App.showScreen("sheet");
+        // Render sheet content (works on hidden elements) and print.
+        // print.css forces #screen-sheet visible and hides everything else,
+        // so no screen switch is needed.
         Sheet.init(this.game);
-        setTimeout(() => window.print(), 300);
+        window.print();
     },
 };


### PR DESCRIPTION
Print Game Sheet now renders sheet content in the background and calls
window.print() synchronously from the click handler. print.css already
forces #screen-sheet visible, so no screen navigation is needed.

This eliminates the race condition between screen transition rendering
and the 300ms setTimeout, and ensures window.print() stays within the
browser's user activation window on mobile.
