### PR TITLE
fix: add ESC/Enter keyboard support to overlay dialogs (#73)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -125,6 +125,41 @@ const App = {
             document.getElementById("qr-overlay").classList.remove("visible");
         });
 
+        // Keyboard: Escape/Enter to close overlays (priority: innermost first)
+        document.addEventListener("keydown", (e) => {
+            if (e.key !== "Escape" && e.key !== "Enter") return;
+
+            // Privacy overlay (stacked on About)
+            if (document.getElementById("privacy-overlay").classList.contains("visible")) {
+                e.preventDefault();
+                document.getElementById("privacy-overlay").classList.remove("visible");
+                document.getElementById("about-overlay").classList.add("visible");
+                return;
+            }
+
+            // License overlay (stacked on About)
+            if (document.getElementById("license-overlay").classList.contains("visible")) {
+                e.preventDefault();
+                document.getElementById("license-overlay").classList.remove("visible");
+                document.getElementById("about-overlay").classList.add("visible");
+                return;
+            }
+
+            // About overlay
+            if (document.getElementById("about-overlay").classList.contains("visible")) {
+                e.preventDefault();
+                document.getElementById("about-overlay").classList.remove("visible");
+                return;
+            }
+
+            // QR overlay
+            if (document.getElementById("qr-overlay").classList.contains("visible")) {
+                e.preventDefault();
+                document.getElementById("qr-overlay").classList.remove("visible");
+                return;
+            }
+        });
+
         // Try to restore saved game
         const saved = Storage.load();
         if (saved && saved.rules) {

--- a/js/confirm.js
+++ b/js/confirm.js
@@ -37,6 +37,18 @@ const ConfirmDialog = {
         document.getElementById("confirm-overlay").addEventListener("click", (e) => {
             if (e.target === e.currentTarget) this._close(false);
         });
+
+        // Keyboard: Escape = cancel, Enter = confirm
+        document.addEventListener("keydown", (e) => {
+            if (!document.getElementById("confirm-overlay").classList.contains("visible")) return;
+            if (e.key === "Escape") {
+                e.preventDefault();
+                this._close(false);
+            } else if (e.key === "Enter") {
+                e.preventDefault();
+                this._close(true);
+            }
+        });
     },
 
     show({ title, message, confirmLabel = "OK", cancelLabel = "Cancel", type = "danger" }) {

--- a/js/events.js
+++ b/js/events.js
@@ -189,6 +189,16 @@ const Events = {
                 return;
             }
         });
+
+        // Keyboard: Escape/Enter to dismiss foul-out overlay
+        document.addEventListener("keydown", (e) => {
+            if (!document.getElementById("foulout-overlay").classList.contains("visible")) return;
+            if (document.getElementById("event-modal").classList.contains("visible")) return;
+            if (e.key === "Escape" || e.key === "Enter") {
+                e.preventDefault();
+                document.getElementById("foulout-overlay").classList.remove("visible");
+            }
+        });
     },
 
     _handleNumpad(val) {


### PR DESCRIPTION
Add keydown listeners to all non-modal overlay dialogs:
- confirm.js: ESC = cancel, Enter = confirm
- app.js: ESC/Enter for About, Privacy, License, QR overlays
  (Privacy/License return to About on dismiss)
- events.js: ESC/Enter to dismiss foul-out overlay

Fixes #73
