### PR TITLE
Redesign logging mode selector (#79)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -283,6 +283,47 @@ select.form-input {
 }
 
 /* ============================
+   Segmented Control
+   ============================ */
+.segment-control {
+  display: flex;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 3px;
+  gap: 3px;
+}
+
+.segment-btn {
+  flex: 1;
+  padding: 10px 8px;
+  border: none;
+  border-radius: calc(var(--radius-md) - 2px);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition);
+  touch-action: manipulation;
+}
+
+.segment-btn.active {
+  background: linear-gradient(135deg, var(--accent-blue) 0%, #6366f1 100%);
+  color: white;
+  box-shadow: 0 1px 4px rgba(59, 130, 246, 0.3);
+}
+
+.segment-btn:disabled {
+  cursor: not-allowed;
+}
+
+.segment-control.disabled {
+  opacity: 0.3;
+}
+
+/* ============================
    Foldable Setup Sections
    ============================ */
 .setup-foldable {

--- a/js/setup.js
+++ b/js/setup.js
@@ -24,7 +24,7 @@ const Setup = {
         this._populateRules();
         this._setDefaultDate();
         this._resetForm();
-        this._bindStatsToggles();
+        this._bindLoggingMode();
     },
 
     _resetForm() {
@@ -34,6 +34,23 @@ const Setup = {
         document.getElementById("setup-rules").disabled = false;
         document.getElementById("setup-overtime").disabled = false;
         document.getElementById("setup-shootout").disabled = false;
+
+        // Reset logging mode segmented control
+        const modeControl = document.getElementById("setup-logging-mode");
+        modeControl.classList.remove("disabled");
+        modeControl.querySelectorAll(".segment-btn").forEach((btn) => {
+            btn.disabled = false;
+            btn.classList.toggle("active", btn.dataset.mode === "log");
+        });
+
+        // Reset stats time segmented control
+        const timeControl = document.getElementById("setup-stats-time-mode");
+        timeControl.querySelectorAll(".segment-btn").forEach((btn) => {
+            btn.classList.toggle("active", btn.dataset.value === "off");
+        });
+
+        this._updateLoggingHeader();
+        this._updateStatsTimeState();
     },
 
     updateForActiveGame(game) {
@@ -140,16 +157,30 @@ const Setup = {
             game.timeoutsAllowed.to30 = parseInt(document.getElementById("setup-to-30").value) || 0;
         });
 
-        // Stats toggles during active game — disable changing mode
-        document.getElementById("setup-enable-log").disabled = true;
-        document.getElementById("setup-enable-stats").disabled = true;
-        document.getElementById("setup-stats-time-mode").disabled = true;
-        document.getElementById("setup-enable-log").checked = game.enableLog;
-        document.getElementById("setup-enable-stats").checked = game.enableStats;
-        document.getElementById("setup-stats-time-mode").value = game.statsTimeMode || "off";
-        this._updateStatsTimeVisibility();
+        // Logging mode — set active buttons and disable during active game
+        const mode = game.enableLog && game.enableStats ? "full"
+            : game.enableStats ? "stats"
+            : "log";
+        const modeControl = document.getElementById("setup-logging-mode");
+        modeControl.classList.add("disabled");
+        modeControl.querySelectorAll(".segment-btn").forEach((btn) => {
+            btn.classList.toggle("active", btn.dataset.mode === mode);
+            btn.disabled = true;
+        });
+
+        // Stats time mode
+        const timeControl = document.getElementById("setup-stats-time-mode");
+        const stm = game.statsTimeMode || "off";
+        timeControl.classList.add("disabled");
+        timeControl.querySelectorAll(".segment-btn").forEach((btn) => {
+            btn.classList.toggle("active", btn.dataset.value === stm);
+            btn.disabled = true;
+        });
+
+        this._updateLoggingHeader();
 
         // Auto-open foldable sections during active game
+        document.getElementById("setup-logging-section").open = true;
         // Game Details: open if any metadata fields are filled
         if (game.date || game.startTime || game.location || game.gameId) {
             document.getElementById("setup-details-section").open = true;
@@ -235,39 +266,55 @@ const Setup = {
         });
     },
 
-    _bindStatsToggles() {
-        const logToggle = document.getElementById("setup-enable-log");
-        const statsToggle = document.getElementById("setup-enable-stats");
+    _getSelectedMode() {
+        const active = document.querySelector("#setup-logging-mode .segment-btn.active");
+        return active ? active.dataset.mode : "log";
+    },
 
-        // Mutual exclusion: can't deselect the last one
-        logToggle.addEventListener("change", () => {
-            if (!logToggle.checked && !statsToggle.checked) {
-                logToggle.checked = true;
-                return;
-            }
-            this._updateStatsTimeDefault();
+    _bindLoggingMode() {
+        // Mode segment control
+        const modeControl = document.getElementById("setup-logging-mode");
+        modeControl.addEventListener("click", (e) => {
+            const btn = e.target.closest(".segment-btn");
+            if (!btn || btn.disabled) return;
+
+            modeControl.querySelectorAll(".segment-btn").forEach((b) => b.classList.remove("active"));
+            btn.classList.add("active");
+
+            this._updateLoggingHeader();
+            this._updateStatsTimeState();
         });
-        statsToggle.addEventListener("change", () => {
-            if (!statsToggle.checked && !logToggle.checked) {
-                statsToggle.checked = true;
-                return;
-            }
-            this._updateStatsTimeVisibility();
-            this._updateStatsTimeDefault();
+
+        // Stats time segment control
+        const timeControl = document.getElementById("setup-stats-time-mode");
+        timeControl.addEventListener("click", (e) => {
+            const btn = e.target.closest(".segment-btn");
+            if (!btn || btn.disabled) return;
+
+            timeControl.querySelectorAll(".segment-btn").forEach((b) => b.classList.remove("active"));
+            btn.classList.add("active");
         });
     },
 
-    _updateStatsTimeVisibility() {
-        const statsOn = document.getElementById("setup-enable-stats").checked;
-        document.getElementById("setup-stats-time-group").style.display = statsOn ? "" : "none";
+    _updateLoggingHeader() {
+        const active = document.querySelector("#setup-logging-mode .segment-btn.active");
+        const label = active ? active.textContent : "Game Log Only";
+        document.getElementById("setup-logging-summary").textContent = label;
     },
 
-    _updateStatsTimeDefault() {
-        const logOn = document.getElementById("setup-enable-log").checked;
-        const statsOn = document.getElementById("setup-enable-stats").checked;
-        if (!statsOn) return;
-        // Default: OFF for both hybrid and stats-only
-        document.getElementById("setup-stats-time-mode").value = "off";
+    _updateStatsTimeState() {
+        const mode = this._getSelectedMode();
+        const statsOn = mode === "full" || mode === "stats";
+        const timeControl = document.getElementById("setup-stats-time-mode");
+        timeControl.classList.toggle("disabled", !statsOn);
+        timeControl.querySelectorAll(".segment-btn").forEach((btn) => {
+            btn.disabled = !statsOn;
+        });
+    },
+
+    _getStatsTimeMode() {
+        const active = document.querySelector("#setup-stats-time-mode .segment-btn.active");
+        return active ? active.dataset.value : "off";
     },
 
     _startGame() {
@@ -289,10 +336,11 @@ const Setup = {
             to30: parseInt(document.getElementById("setup-to-30").value) || 0,
         };
 
-        // Stats settings
-        game.enableLog = document.getElementById("setup-enable-log").checked;
-        game.enableStats = document.getElementById("setup-enable-stats").checked;
-        game.statsTimeMode = document.getElementById("setup-stats-time-mode").value;
+        // Logging mode from segmented control
+        const mode = this._getSelectedMode();
+        game.enableLog = mode === "log" || mode === "full";
+        game.enableStats = mode === "full" || mode === "stats";
+        game.statsTimeMode = this._getStatsTimeMode();
 
         const whiteName = document.getElementById("setup-white-name").value.trim();
         const darkName = document.getElementById("setup-dark-name").value.trim();

--- a/screens/setup.html
+++ b/screens/setup.html
@@ -34,25 +34,28 @@
   </div>
 </div>
 
-<!-- ── Logging Mode (always visible) ── -->
-<div id="setup-stats-section" class="form-row toggle-row">
-  <label class="toggle-label">
-    <input id="setup-enable-log" type="checkbox" checked>
-    <span>Game Log</span>
-  </label>
-  <label class="toggle-label">
-    <input id="setup-enable-stats" type="checkbox">
-    <span>Stats</span>
-  </label>
-</div>
-<div class="form-group" id="setup-stats-time-group" style="display: none;">
-  <label for="setup-stats-time-mode">Stats Time Entry</label>
-  <select id="setup-stats-time-mode" class="form-input">
-    <option value="off">Disabled</option>
-    <option value="optional">Optional</option>
-    <option value="on">Required</option>
-  </select>
-</div>
+<!-- ── Logging (collapsed by default) ── -->
+<details id="setup-logging-section" class="setup-foldable">
+  <summary class="setup-foldable-header">Logging: <span id="setup-logging-summary">Game Log Only</span></summary>
+  <div class="setup-foldable-content">
+    <div class="form-group">
+      <label>Mode</label>
+      <div id="setup-logging-mode" class="segment-control">
+        <button type="button" class="segment-btn active" data-mode="log">Game Log Only</button>
+        <button type="button" class="segment-btn" data-mode="full">Both</button>
+        <button type="button" class="segment-btn" data-mode="stats">Stats Only</button>
+      </div>
+    </div>
+    <div class="form-group" id="setup-stats-time-group">
+      <label>Stats Time Entry</label>
+      <div id="setup-stats-time-mode" class="segment-control disabled">
+        <button type="button" class="segment-btn active" data-value="off" disabled>Disabled</button>
+        <button type="button" class="segment-btn" data-value="optional" disabled>Optional</button>
+        <button type="button" class="segment-btn" data-value="on" disabled>Required</button>
+      </div>
+    </div>
+  </div>
+</details>
 
 <!-- ── Game Details (collapsed by default) ── -->
 <details id="setup-details-section" class="setup-foldable">


### PR DESCRIPTION
Replace two checkboxes + dropdown with a foldable section containing
two segmented controls (Mode: Game Log Only / Both / Stats Only and
Stats Time Entry: Disabled / Optional / Required).

- Wrap logging controls in collapsible <details> section
- Dynamic header text reflects selected mode
- Stats Time Entry dimmed (not hidden) when stats disabled
- Replace Stats Time Entry dropdown with segmented control
- Add .segment-control and .segment-btn CSS styles
- Data model unchanged (enableLog/enableStats booleans)
