### PR TITLE
Redesign Game Setup section (#80)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -324,6 +324,65 @@ select.form-input {
 }
 
 /* ============================
+   Stepper Control
+   ============================ */
+.stepper {
+  display: flex;
+  align-items: center;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 3px;
+  gap: 4px;
+}
+
+.stepper-btn {
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: calc(var(--radius-md) - 2px);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-secondary);
+  font-family: var(--font);
+  font-size: 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition);
+  touch-action: manipulation;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.stepper-btn:active:not(:disabled) {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.stepper-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.stepper-value {
+  flex: 1;
+  text-align: center;
+  font-family: var(--font);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  user-select: none;
+}
+
+.stepper.disabled {
+  opacity: 0.3;
+}
+
+.stepper.disabled .stepper-btn {
+  cursor: not-allowed;
+}
+
+/* ============================
    Foldable Setup Sections
    ============================ */
 .setup-foldable {

--- a/js/events.js
+++ b/js/events.js
@@ -486,9 +486,9 @@ const Events = {
             const used = Game.getTimeoutsUsed(this.game, this.selectedTeam);
             const allowed = this.game.timeoutsAllowed || { full: 0, to30: 0 };
             const teamLabel = this.selectedTeam === "W" ? "White" : "Dark";
-            if (eventDef.code === "TO" && used.full > allowed.full) {
+            if (eventDef.code === "TO" && allowed.full !== -1 && used.full > allowed.full) {
                 this._showToast(`⚠️ ${teamLabel} exceeded full timeout limit (${allowed.full})`, "warning");
-            } else if (eventDef.code === "TO30" && used.to30 > allowed.to30) {
+            } else if (eventDef.code === "TO30" && allowed.to30 !== -1 && used.to30 > allowed.to30) {
                 this._showToast(`⚠️ ${teamLabel} exceeded 30s timeout limit (${allowed.to30})`, "warning");
             }
         }
@@ -607,11 +607,12 @@ const Events = {
         const el = document.getElementById(elementId);
         const left = Game.getTimeoutsLeft(this.game, team);
         const allowed = this.game.timeoutsAllowed || { full: 0, to30: 0 };
+        const fmtVal = (v) => v === Infinity ? "\u221e" : v;
         let text;
-        if (allowed.to30 > 0) {
-            text = `TOL ${left.full}/${left.to30}`;
+        if (allowed.to30 !== 0) {
+            text = `TOL ${fmtVal(left.full)}/${fmtVal(left.to30)}`;
         } else {
-            text = `TOL ${left.full}`;
+            text = `TOL ${fmtVal(left.full)}`;
         }
         el.textContent = text;
         el.classList.toggle("tol-warning", left.full === 0 && left.to30 === 0);

--- a/js/game.js
+++ b/js/game.js
@@ -195,8 +195,8 @@ const Game = {
         const used = this.getTimeoutsUsed(game, team);
         const allowed = game.timeoutsAllowed || { full: 0, to30: 0 };
         return {
-            full: Math.max(0, allowed.full - used.full),
-            to30: Math.max(0, allowed.to30 - used.to30),
+            full: allowed.full === -1 ? Infinity : Math.max(0, allowed.full - used.full),
+            to30: allowed.to30 === -1 ? Infinity : Math.max(0, allowed.to30 - used.to30),
         };
     },
 

--- a/js/setup.js
+++ b/js/setup.js
@@ -20,7 +20,7 @@ const Setup = {
     init(onStart) {
         this.onStart = onStart;
         this._bindEvents();
-        this._populatePeriodLengths();
+        this._bindSteppers();
         this._populateRules();
         this._setDefaultDate();
         this._resetForm();
@@ -32,8 +32,6 @@ const Setup = {
         document.getElementById("setup-start-btn").disabled = false;
         document.getElementById("setup-start-btn").textContent = "Start Game";
         document.getElementById("setup-rules").disabled = false;
-        document.getElementById("setup-overtime").disabled = false;
-        document.getElementById("setup-shootout").disabled = false;
 
         // Reset logging mode segmented control
         const modeControl = document.getElementById("setup-logging-mode");
@@ -47,6 +45,18 @@ const Setup = {
         const timeControl = document.getElementById("setup-stats-time-mode");
         timeControl.querySelectorAll(".segment-btn").forEach((btn) => {
             btn.classList.toggle("active", btn.dataset.value === "off");
+        });
+
+        // Reset post-regulation segmented control
+        const prControl = document.getElementById("setup-post-regulation");
+        prControl.classList.remove("disabled");
+        prControl.querySelectorAll(".segment-btn").forEach((btn) => {
+            btn.disabled = false;
+        });
+
+        // Re-enable all steppers
+        document.querySelectorAll("#setup-advanced-section .stepper").forEach((s) => {
+            this._setStepperDisabled(s, false);
         });
 
         this._updateLoggingHeader();
@@ -103,17 +113,9 @@ const Setup = {
         // Disable rules change during game
         document.getElementById("setup-rules").disabled = true;
 
-        // Disable OT if any OT period has started
+        // Disable OT/SO if that phase has started
         const hasOT = game.log.some((e) => typeof e.period === "string" && e.period.startsWith("OT"));
-        if (hasOT) {
-            document.getElementById("setup-overtime").disabled = true;
-        }
-
-        // Disable SO if shootout has started
         const hasSO = game.log.some((e) => e.period === "SO");
-        if (hasSO) {
-            document.getElementById("setup-shootout").disabled = true;
-        }
 
         // Live-save editable fields back to the active game
         const saveField = (id, setter) => {
@@ -134,27 +136,6 @@ const Setup = {
         saveField("setup-dark-name", () => {
             const v = document.getElementById("setup-dark-name").value.trim();
             game.dark.name = v || "Dark";
-        });
-        if (!hasOT) {
-            saveField("setup-overtime", () => {
-                game.overtime = document.getElementById("setup-overtime").checked;
-                this._updateOTLengthVisibility();
-            });
-        }
-        if (!hasSO) {
-            saveField("setup-shootout", () => { game.shootout = document.getElementById("setup-shootout").checked; });
-        }
-        saveField("setup-period-length", () => {
-            game.periodLength = parseInt(document.getElementById("setup-period-length").value);
-        });
-        saveField("setup-ot-length", () => {
-            game.otPeriodLength = parseInt(document.getElementById("setup-ot-length").value);
-        });
-        saveField("setup-to-full", () => {
-            game.timeoutsAllowed.full = parseInt(document.getElementById("setup-to-full").value) || 0;
-        });
-        saveField("setup-to-30", () => {
-            game.timeoutsAllowed.to30 = parseInt(document.getElementById("setup-to-30").value) || 0;
         });
 
         // Logging mode — set active buttons and disable during active game
@@ -179,6 +160,28 @@ const Setup = {
 
         this._updateLoggingHeader();
 
+        // Post-regulation — set active and disable
+        const prValue = game.overtime ? "overtime" : game.shootout ? "shootout" : "none";
+        const prControl = document.getElementById("setup-post-regulation");
+        if (hasOT || hasSO) {
+            prControl.classList.add("disabled");
+        }
+        prControl.querySelectorAll(".segment-btn").forEach((btn) => {
+            btn.classList.toggle("active", btn.dataset.value === prValue);
+            if (hasOT || hasSO) btn.disabled = true;
+        });
+
+        // Steppers — set values and disable
+        this._setStepperValue("setup-period-length", game.periodLength);
+        this._setStepperValue("setup-ot-length", game.otPeriodLength || 3);
+        this._setStepperValue("setup-to-full", game.timeoutsAllowed.full);
+        this._setStepperValue("setup-to-30", game.timeoutsAllowed.to30);
+        document.querySelectorAll("#setup-advanced-section .stepper").forEach((s) => {
+            this._setStepperDisabled(s, true);
+        });
+        this._updateOTLengthState();
+        this._updateGameSetupHeader();
+
         // Auto-open foldable sections during active game
         document.getElementById("setup-logging-section").open = true;
         // Game Details: open if any metadata fields are filled
@@ -202,26 +205,120 @@ const Setup = {
         this._updateToggles();
     },
 
-    _populatePeriodLengths() {
-        const selects = ["setup-period-length", "setup-ot-length"];
-        for (const id of selects) {
-            const sel = document.getElementById(id);
-            sel.innerHTML = "";
-            for (let m = 3; m <= 9; m++) {
-                const opt = document.createElement("option");
-                opt.value = m;
-                opt.textContent = m + " min";
-                sel.appendChild(opt);
-            }
-        }
+    // ── Stepper helpers ──
+
+    _getStepperValue(id) {
+        return parseInt(document.getElementById(id).dataset.value);
     },
 
-    _updateOTLengthVisibility() {
-        const otChecked = document.getElementById("setup-overtime").checked;
+    _setStepperValue(id, val) {
+        const el = document.getElementById(id);
+        const min = parseInt(el.dataset.min);
+        const max = parseInt(el.dataset.max);
+        const hasUnlimited = el.dataset.unlimited === "true";
+
+        // Clamp value: allow -1 (unlimited) if supported
+        if (val === -1 && hasUnlimited) {
+            // keep as -1
+        } else {
+            val = Math.max(min, Math.min(max, val));
+        }
+        el.dataset.value = val;
+
+        const display = el.querySelector(".stepper-value");
+        if (val === -1) {
+            display.textContent = "\u221e";
+        } else {
+            display.textContent = val + (el.dataset.suffix || "");
+        }
+
+        // Update +/- disabled states
+        const isDisabled = el.classList.contains("disabled");
+        el.querySelector(".stepper-dec").disabled = (val !== -1 && val <= min) || isDisabled;
+        el.querySelector(".stepper-inc").disabled = (val === -1) || isDisabled;
+
+        // Update shortcut button highlighting
+        el.querySelectorAll(".stepper-set").forEach((btn) => {
+            btn.classList.toggle("active", parseInt(btn.dataset.set) === val);
+        });
+    },
+
+    _setStepperDisabled(el, disabled) {
+        el.classList.toggle("disabled", disabled);
+        el.querySelectorAll(".stepper-btn").forEach((b) => { b.disabled = disabled; });
+    },
+
+    _bindSteppers() {
+        document.querySelectorAll(".stepper").forEach((stepper) => {
+            stepper.addEventListener("click", (e) => {
+                const btn = e.target.closest(".stepper-btn");
+                if (!btn || btn.disabled) return;
+
+                // Shortcut button (Off / ∞)
+                if (btn.classList.contains("stepper-set")) {
+                    this._setStepperValue(stepper.id, parseInt(btn.dataset.set));
+                    this._updateGameSetupHeader();
+                    return;
+                }
+
+                const cur = parseInt(stepper.dataset.value);
+                const max = parseInt(stepper.dataset.max);
+                const hasUnlimited = stepper.dataset.unlimited === "true";
+
+                if (btn.classList.contains("stepper-inc")) {
+                    // At max → jump to unlimited if supported
+                    const next = (cur >= max && hasUnlimited) ? -1 : cur + 1;
+                    this._setStepperValue(stepper.id, next);
+                } else {
+                    // At unlimited → jump back to max
+                    const next = (cur === -1) ? max : cur - 1;
+                    this._setStepperValue(stepper.id, next);
+                }
+                this._updateGameSetupHeader();
+            });
+        });
+    },
+
+    // ── OT Length + Game Setup header ──
+
+    _getPostRegulation() {
+        const active = document.querySelector("#setup-post-regulation .segment-btn.active");
+        return active ? active.dataset.value : "none";
+    },
+
+    _updateOTLengthState() {
+        const pr = this._getPostRegulation();
+        const otOn = pr === "overtime";
         const group = document.getElementById("setup-ot-length-group");
-        const select = document.getElementById("setup-ot-length");
-        select.disabled = !otChecked;
-        group.style.opacity = otChecked ? "" : "0.35";
+        const stepper = document.getElementById("setup-ot-length");
+        this._setStepperDisabled(stepper, !otOn);
+        group.style.opacity = otOn ? "" : "0.35";
+        // Re-apply boundary states
+        if (otOn) this._setStepperValue("setup-ot-length", this._getStepperValue("setup-ot-length"));
+    },
+
+    _updateGameSetupHeader() {
+        const qLen = this._getStepperValue("setup-period-length");
+        const pr = this._getPostRegulation();
+        const parts = [qLen + " min"];
+
+        if (pr === "overtime") {
+            const otLen = this._getStepperValue("setup-ot-length");
+            parts.push("OT " + otLen + " min");
+        } else if (pr === "shootout") {
+            parts.push("Shootout");
+        }
+
+        // Timeout summary: NxTO / MxTO30, skip zero sides
+        const full = this._getStepperValue("setup-to-full");
+        const to30 = this._getStepperValue("setup-to-30");
+        const fmt = (v, label) => v === -1 ? "\u221e " + label : v + "\u00d7" + label;
+        const toParts = [];
+        if (full !== 0) toParts.push(fmt(full, "TO"));
+        if (to30 !== 0) toParts.push(fmt(to30, "TO30"));
+        if (toParts.length) parts.push(toParts.join(" / "));
+
+        document.getElementById("setup-game-summary").textContent = parts.join(" \u00b7 ");
     },
 
     _setDefaultDate() {
@@ -232,13 +329,21 @@ const Setup = {
     _updateToggles() {
         const rulesKey = document.getElementById("setup-rules").value;
         const rules = RULES[rulesKey];
-        document.getElementById("setup-overtime").checked = rules.overtime;
-        document.getElementById("setup-shootout").checked = rules.shootout;
-        document.getElementById("setup-period-length").value = rules.periodLength;
-        document.getElementById("setup-ot-length").value = rules.otPeriodLength || 3;
-        this._updateOTLengthVisibility();
-        document.getElementById("setup-to-full").value = rules.timeouts.full;
-        document.getElementById("setup-to-30").value = rules.timeouts.to30;
+
+        // Post-regulation segmented control
+        const prValue = rules.overtime ? "overtime" : rules.shootout ? "shootout" : "none";
+        document.querySelectorAll("#setup-post-regulation .segment-btn").forEach((btn) => {
+            btn.classList.toggle("active", btn.dataset.value === prValue);
+        });
+
+        // Steppers
+        this._setStepperValue("setup-period-length", rules.periodLength);
+        this._setStepperValue("setup-ot-length", rules.otPeriodLength || 3);
+        this._setStepperValue("setup-to-full", rules.timeouts.full);
+        this._setStepperValue("setup-to-30", rules.timeouts.to30);
+
+        this._updateOTLengthState();
+        this._updateGameSetupHeader();
     },
 
     _bindEvents() {
@@ -246,14 +351,15 @@ const Setup = {
             this._updateToggles();
         });
 
-        // OT and SO are mutually exclusive
-        document.getElementById("setup-overtime").addEventListener("change", (e) => {
-            if (e.target.checked) document.getElementById("setup-shootout").checked = false;
-            this._updateOTLengthVisibility();
-        });
-        document.getElementById("setup-shootout").addEventListener("change", (e) => {
-            if (e.target.checked) document.getElementById("setup-overtime").checked = false;
-            this._updateOTLengthVisibility();
+        // Post-regulation segmented control
+        const prControl = document.getElementById("setup-post-regulation");
+        prControl.addEventListener("click", (e) => {
+            const btn = e.target.closest(".segment-btn");
+            if (!btn || btn.disabled) return;
+            prControl.querySelectorAll(".segment-btn").forEach((b) => b.classList.remove("active"));
+            btn.classList.add("active");
+            this._updateOTLengthState();
+            this._updateGameSetupHeader();
         });
 
         document.getElementById("setup-start-btn").addEventListener("click", () => {
@@ -325,15 +431,16 @@ const Setup = {
         game.startTime = document.getElementById("setup-time").value;
         game.location = document.getElementById("setup-location").value;
         game.gameId = document.getElementById("setup-game-id").value.trim();
-        game.overtime = document.getElementById("setup-overtime").checked;
-        game.shootout = document.getElementById("setup-shootout").checked;
-        game.periodLength = parseInt(document.getElementById("setup-period-length").value);
+        const pr = this._getPostRegulation();
+        game.overtime = pr === "overtime";
+        game.shootout = pr === "shootout";
+        game.periodLength = this._getStepperValue("setup-period-length");
         game.otPeriodLength = game.overtime
-            ? parseInt(document.getElementById("setup-ot-length").value)
+            ? this._getStepperValue("setup-ot-length")
             : null;
         game.timeoutsAllowed = {
-            full: parseInt(document.getElementById("setup-to-full").value) || 0,
-            to30: parseInt(document.getElementById("setup-to-30").value) || 0,
+            full: this._getStepperValue("setup-to-full"),
+            to30: this._getStepperValue("setup-to-30"),
         };
 
         // Logging mode from segmented control

--- a/screens/setup.html
+++ b/screens/setup.html
@@ -86,38 +86,54 @@
 
 <!-- ── Game Setup (collapsed by default) ── -->
 <details id="setup-advanced-section" class="setup-foldable">
-  <summary class="setup-foldable-header">Game Setup (duration, timeouts)</summary>
+  <summary class="setup-foldable-header">Game Setup: <span id="setup-game-summary">8 min · Overtime</span></summary>
   <div class="setup-foldable-content">
-    <div class="form-row toggle-row">
-      <label class="toggle-label">
-        <input id="setup-overtime" type="checkbox">
-        <span>Overtime</span>
-      </label>
-      <label class="toggle-label">
-        <input id="setup-shootout" type="checkbox">
-        <span>Shootout</span>
-      </label>
+    <div class="form-group">
+      <label>Post-Regulation</label>
+      <div id="setup-post-regulation" class="segment-control">
+        <button type="button" class="segment-btn" data-value="none">None</button>
+        <button type="button" class="segment-btn active" data-value="overtime">Overtime</button>
+        <button type="button" class="segment-btn" data-value="shootout">Shootout</button>
+      </div>
     </div>
 
     <div class="form-row">
       <div class="form-group">
-        <label for="setup-period-length">Quarter Length</label>
-        <select id="setup-period-length" class="form-input"></select>
+        <label>Quarter Length</label>
+        <div id="setup-period-length" class="stepper" data-min="1" data-max="9" data-value="8" data-suffix=" min">
+          <button type="button" class="stepper-btn stepper-dec" aria-label="Decrease">−</button>
+          <span class="stepper-value">8 min</span>
+          <button type="button" class="stepper-btn stepper-inc" aria-label="Increase">+</button>
+        </div>
       </div>
       <div class="form-group" id="setup-ot-length-group">
-        <label for="setup-ot-length">OT Length</label>
-        <select id="setup-ot-length" class="form-input"></select>
+        <label>OT Length</label>
+        <div id="setup-ot-length" class="stepper" data-min="1" data-max="9" data-value="3" data-suffix=" min">
+          <button type="button" class="stepper-btn stepper-dec" aria-label="Decrease">−</button>
+          <span class="stepper-value">3 min</span>
+          <button type="button" class="stepper-btn stepper-inc" aria-label="Increase">+</button>
+        </div>
       </div>
     </div>
 
     <div class="form-row">
       <div class="form-group">
-        <label for="setup-to-full">Full TOs (per team)</label>
-        <input id="setup-to-full" type="number" class="form-input" min="0" max="9" value="3">
+        <label>Full TOs (per team)</label>
+        <div id="setup-to-full" class="stepper" data-min="0" data-max="3" data-value="3" data-unlimited="true">
+          <button type="button" class="stepper-btn stepper-dec" aria-label="Decrease">−</button>
+          <span class="stepper-value">3</span>
+          <button type="button" class="stepper-btn stepper-inc" aria-label="Increase">+</button>
+          <button type="button" class="stepper-btn stepper-set" data-set="-1" aria-label="Unlimited">∞</button>
+        </div>
       </div>
       <div class="form-group">
-        <label for="setup-to-30">30s TOs (per team)</label>
-        <input id="setup-to-30" type="number" class="form-input" min="0" max="9" value="1">
+        <label>30s TOs (per team)</label>
+        <div id="setup-to-30" class="stepper" data-min="0" data-max="3" data-value="1" data-unlimited="true">
+          <button type="button" class="stepper-btn stepper-dec" aria-label="Decrease">−</button>
+          <span class="stepper-value">1</span>
+          <button type="button" class="stepper-btn stepper-inc" aria-label="Increase">+</button>
+          <button type="button" class="stepper-btn stepper-set" data-set="-1" aria-label="Unlimited">∞</button>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Replace checkboxes, dropdowns, and number inputs with modern controls:

- OT/Shootout checkboxes → 3-option segmented control (None/Overtime/Shootout)
- Period length dropdowns → stepper controls (range 1-9 min)
- Timeout number inputs → stepper controls with ∞ shortcut button
- Dynamic fold header showing all enabled settings
- Unlimited timeout support (-1 sentinel, ∞ display, skip over-limit warnings)
- OT Length stepper dimmed when OT not selected
- Quarter/OT length range extended from 3-9 to 1-9 min
