### PR TITLE
Fix Setup tab crash + add Restart App (#83)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -493,6 +493,22 @@ select.form-input {
   margin-top: 8px;
 }
 
+.hard-reset-link {
+  display: block;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-secondary);
+  text-decoration: none;
+  margin-top: 12px;
+  padding: 4px;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.hard-reset-link:hover {
+  color: var(--danger);
+}
+
 .btn-small {
   padding: 8px 16px;
   font-size: 12px;

--- a/js/app.js
+++ b/js/app.js
@@ -188,6 +188,25 @@ const App = {
             }
         });
 
+        // Hard Reset — uses native confirm() so it works even when custom code is broken
+        document.getElementById("setup-hard-reset").addEventListener("click", (e) => {
+            e.preventDefault();
+            // eslint-disable-next-line no-restricted-globals
+            if (!confirm("Restart wplog?\n\nThis will erase all game data, clear the cache, and reload the app. This cannot be undone.")) return;
+            localStorage.clear();
+            if ("serviceWorker" in navigator) {
+                navigator.serviceWorker.getRegistrations().then((regs) => {
+                    regs.forEach((r) => r.unregister());
+                });
+            }
+            if ("caches" in window) {
+                caches.keys().then((names) => {
+                    names.forEach((name) => caches.delete(name));
+                });
+            }
+            location.reload();
+        });
+
         document.getElementById("nav-live").addEventListener("click", () => {
             if (this.game) {
                 this.showScreen("live");

--- a/js/setup.js
+++ b/js/setup.js
@@ -74,14 +74,6 @@ const Setup = {
         timeEl.classList.toggle("has-value", !!timeEl.value);
         document.getElementById("setup-location").value = game.location || "";
         document.getElementById("setup-game-id").value = game.gameId || "";
-        document.getElementById("setup-overtime").checked = game.overtime;
-        document.getElementById("setup-shootout").checked = game.shootout;
-        document.getElementById("setup-period-length").value = game.periodLength || 8;
-        document.getElementById("setup-ot-length").value = game.otPeriodLength || 3;
-        this._updateOTLengthVisibility();
-        const ta = game.timeoutsAllowed || { full: 0, to30: 0 };
-        document.getElementById("setup-to-full").value = ta.full;
-        document.getElementById("setup-to-30").value = ta.to30;
         document.getElementById("setup-white-name").value = game.white.name === "White" ? "" : game.white.name;
         document.getElementById("setup-dark-name").value = game.dark.name === "Dark" ? "" : game.dark.name;
 

--- a/screens/setup.html
+++ b/screens/setup.html
@@ -140,3 +140,4 @@
 </details>
 
 <button id="setup-start-btn" class="btn btn-primary btn-large">Start Game</button>
+<a id="setup-hard-reset" class="hard-reset-link" href="#">Restart App</a>


### PR DESCRIPTION
- Remove stale element references in updateForActiveGame() that crashed
  on deleted checkbox/input elements (setup-overtime, setup-shootout,
  old .value on stepper divs). The correct code for these already exists
  later in the function using segmented controls and _setStepperValue().
- Add 'Restart App' link on Setup screen (below Start/End Game button).
  Uses native confirm() so it works even when custom code is broken.
  Clears localStorage, unregisters service worker, clears caches, reloads.
