### PR TITLE
Move paper size to print dialog popup (#78)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1605,26 +1605,40 @@ select.form-input {
   gap: 12px;
 }
 
-.print-options {
+/* Print Dialog */
+.print-card {
+  max-width: 380px;
+  text-align: center;
+}
+
+.print-title {
+  margin-bottom: 20px;
+}
+
+.print-card .form-group {
+  text-align: left;
+  margin-bottom: 20px;
+}
+
+.print-dialog-actions {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 12px;
+  align-items: center;
 }
 
-.print-paper-label {
-  font-size: 12px;
-  font-weight: 600;
+.btn-link {
+  background: none;
+  border: none;
   color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  white-space: nowrap;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 8px 16px;
+  transition: color 0.15s;
 }
 
-.print-paper-select {
-  flex: 1;
-  padding: 10px 14px;
-  min-height: 40px;
-  font-size: 14px;
+.btn-link:hover {
+  color: var(--text-primary);
 }
 
 .share-status {

--- a/index.html
+++ b/index.html
@@ -112,6 +112,24 @@
     </div>
   </div>
 
+  <!-- Print Dialog -->
+  <div id="print-overlay" class="overlay">
+    <div class="overlay-content print-card">
+      <div class="overlay-title print-title">Print Game Sheet</div>
+      <div class="form-group">
+        <label>Paper Size</label>
+        <div id="print-paper-size" class="segment-control">
+          <button type="button" class="segment-btn active" data-value="letter">US Letter</button>
+          <button type="button" class="segment-btn" data-value="a4">A4</button>
+        </div>
+      </div>
+      <div class="print-dialog-actions">
+        <button id="print-confirm" class="btn btn-primary btn-large">Print</button>
+        <button id="print-cancel" class="btn-link">Cancel</button>
+      </div>
+    </div>
+  </div>
+
   <!-- QR Code Full-Screen Overlay -->
   <div id="qr-overlay" class="overlay qr-overlay">
     <div class="qr-fullscreen-wrap">

--- a/js/app.js
+++ b/js/app.js
@@ -129,6 +129,18 @@ const App = {
         document.addEventListener("keydown", (e) => {
             if (e.key !== "Escape" && e.key !== "Enter") return;
 
+            // Print dialog (Escape=cancel, Enter=print)
+            if (document.getElementById("print-overlay").classList.contains("visible")) {
+                e.preventDefault();
+                if (e.key === "Escape") {
+                    Share._closePrintDialog();
+                } else if (e.key === "Enter") {
+                    Share._closePrintDialog();
+                    Share._doPrint();
+                }
+                return;
+            }
+
             // Privacy overlay (stacked on About)
             if (document.getElementById("privacy-overlay").classList.contains("visible")) {
                 e.preventDefault();

--- a/js/share.js
+++ b/js/share.js
@@ -20,6 +20,7 @@ const Share = {
     game: null,
     _bound: false,
     _pageStyleEl: null,
+    _paperSize: "letter",
 
     init(game) {
         this.game = game || null;
@@ -27,23 +28,57 @@ const Share = {
         btn.disabled = !this.game;
         if (!this._bound) {
             btn.addEventListener("click", () => {
-                this.printSheet();
+                this._showPrintDialog();
             });
+
+            // Paper size segmented control
+            const control = document.getElementById("print-paper-size");
+            control.addEventListener("click", (e) => {
+                const btn = e.target.closest(".segment-btn");
+                if (!btn) return;
+                control.querySelectorAll(".segment-btn").forEach((b) => b.classList.remove("active"));
+                btn.classList.add("active");
+                this._paperSize = btn.dataset.value;
+            });
+
+            // Print confirm
+            document.getElementById("print-confirm").addEventListener("click", () => {
+                this._closePrintDialog();
+                this._doPrint();
+            });
+
+            // Cancel
+            document.getElementById("print-cancel").addEventListener("click", () => {
+                this._closePrintDialog();
+            });
+
+            // Backdrop click = cancel
+            document.getElementById("print-overlay").addEventListener("click", (e) => {
+                if (e.target === e.currentTarget) this._closePrintDialog();
+            });
+
             this._bound = true;
         }
     },
 
-    printSheet() {
+    _showPrintDialog() {
         if (!this.game) return;
-        const paperSize = document.getElementById("print-paper-size").value;
+        // Sync segmented control to current selection
+        const control = document.getElementById("print-paper-size");
+        control.querySelectorAll(".segment-btn").forEach((btn) => {
+            btn.classList.toggle("active", btn.dataset.value === this._paperSize);
+        });
+        document.getElementById("print-overlay").classList.add("visible");
+    },
 
-        // Inject dynamic @page size
-        this._setPageSize(paperSize);
+    _closePrintDialog() {
+        document.getElementById("print-overlay").classList.remove("visible");
+    },
 
-        // Render sheet content (works on hidden elements) and print.
-        // print.css forces #screen-sheet visible and hides everything else,
-        // so no screen switch is needed.
-        Sheet.init(this.game, paperSize);
+    _doPrint() {
+        if (!this.game) return;
+        this._setPageSize(this._paperSize);
+        Sheet.init(this.game, this._paperSize);
         window.print();
     },
 

--- a/screens/share.html
+++ b/screens/share.html
@@ -19,12 +19,5 @@
   <p class="qr-label">Scan to open wplog</p>
 </div>
 <div class="share-buttons">
-  <div class="print-options">
-    <label for="print-paper-size" class="print-paper-label">Paper Size</label>
-    <select id="print-paper-size" class="form-input print-paper-select">
-      <option value="letter">US Letter</option>
-      <option value="a4">A4</option>
-    </select>
-  </div>
   <button id="print-sheet-btn" class="btn btn-primary btn-large">Print Game Sheet</button>
 </div>


### PR DESCRIPTION
- Remove paper size dropdown from share screen (just QR + Print button)
- Print button opens popup overlay with paper size segmented control
- Keyboard: Escape cancels, Enter prints
- Backdrop click closes popup
- Paper size remembered between opens (in-memory)
- Reuses existing overlay CSS pattern
