### PR TITLE
Add CSV download with editable filename (#68)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1611,6 +1611,19 @@ select.form-input {
   text-align: center;
 }
 
+.csv-filename {
+  font-family: "Source Code Pro", monospace;
+  font-size: 13px;
+  color: var(--text-primary);
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  margin-bottom: 20px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
 .print-title {
   margin-bottom: 20px;
 }

--- a/index.html
+++ b/index.html
@@ -130,6 +130,18 @@
     </div>
   </div>
 
+  <!-- CSV Export Dialog -->
+  <div id="csv-overlay" class="overlay">
+    <div class="overlay-content print-card">
+      <div class="overlay-title print-title">Export CSV</div>
+      <input type="text" id="csv-filename" class="csv-filename" spellcheck="false" autocomplete="off">
+      <div class="print-dialog-actions">
+        <button id="csv-confirm" class="btn btn-primary btn-large">Download</button>
+        <button id="csv-cancel" class="btn-link">Cancel</button>
+      </div>
+    </div>
+  </div>
+
   <!-- QR Code Full-Screen Overlay -->
   <div id="qr-overlay" class="overlay qr-overlay">
     <div class="qr-fullscreen-wrap">

--- a/js/app.js
+++ b/js/app.js
@@ -141,6 +141,18 @@ const App = {
                 return;
             }
 
+            // CSV export overlay
+            if (document.getElementById("csv-overlay").classList.contains("visible")) {
+                e.preventDefault();
+                if (e.key === "Escape") {
+                    Share._closeCSVDialog();
+                } else if (e.key === "Enter") {
+                    Share._closeCSVDialog();
+                    Share._doExport();
+                }
+                return;
+            }
+
             // Privacy overlay (stacked on About)
             if (document.getElementById("privacy-overlay").classList.contains("visible")) {
                 e.preventDefault();

--- a/js/share.js
+++ b/js/share.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// wplog — Share / Print
+// wplog — Share / Print / Export
 
 const Share = {
     game: null,
@@ -24,11 +24,17 @@ const Share = {
 
     init(game) {
         this.game = game || null;
-        const btn = document.getElementById("print-sheet-btn");
-        btn.disabled = !this.game;
+        const printBtn = document.getElementById("print-sheet-btn");
+        const csvBtn = document.getElementById("export-csv-btn");
+        printBtn.disabled = !this.game;
+        csvBtn.disabled = !this.game;
         if (!this._bound) {
-            btn.addEventListener("click", () => {
+            printBtn.addEventListener("click", () => {
                 this._showPrintDialog();
+            });
+
+            csvBtn.addEventListener("click", () => {
+                this._showCSVDialog();
             });
 
             // Paper size segmented control
@@ -47,23 +53,40 @@ const Share = {
                 this._doPrint();
             });
 
-            // Cancel
+            // Print cancel
             document.getElementById("print-cancel").addEventListener("click", () => {
                 this._closePrintDialog();
             });
 
-            // Backdrop click = cancel
+            // Print backdrop click = cancel
             document.getElementById("print-overlay").addEventListener("click", (e) => {
                 if (e.target === e.currentTarget) this._closePrintDialog();
+            });
+
+            // CSV confirm
+            document.getElementById("csv-confirm").addEventListener("click", () => {
+                this._closeCSVDialog();
+                this._doExport();
+            });
+
+            // CSV cancel
+            document.getElementById("csv-cancel").addEventListener("click", () => {
+                this._closeCSVDialog();
+            });
+
+            // CSV backdrop click = cancel
+            document.getElementById("csv-overlay").addEventListener("click", (e) => {
+                if (e.target === e.currentTarget) this._closeCSVDialog();
             });
 
             this._bound = true;
         }
     },
 
+    // ── Print Dialog ─────────────────────────────────────────
+
     _showPrintDialog() {
         if (!this.game) return;
-        // Sync segmented control to current selection
         const control = document.getElementById("print-paper-size");
         control.querySelectorAll(".segment-btn").forEach((btn) => {
             btn.classList.toggle("active", btn.dataset.value === this._paperSize);
@@ -89,5 +112,80 @@ const Share = {
         }
         const cssSize = size === "a4" ? "A4 portrait" : "letter portrait";
         this._pageStyleEl.textContent = `@page { size: ${cssSize}; margin: 0.5in; }`;
+    },
+
+    // ── CSV Export Dialog ────────────────────────────────────
+
+    _showCSVDialog() {
+        if (!this.game) return;
+        const input = document.getElementById("csv-filename");
+        input.value = this._buildFilename();
+        document.getElementById("csv-overlay").classList.add("visible");
+        input.focus();
+        input.select();
+    },
+
+    _closeCSVDialog() {
+        document.getElementById("csv-overlay").classList.remove("visible");
+    },
+
+    _buildFilename() {
+        const parts = ["wplog"];
+
+        // Date
+        const date = this.game.date || new Date().toISOString().slice(0, 10);
+        parts.push(date);
+
+        // Teams (only if custom)
+        const w = this.game.white.name;
+        const d = this.game.dark.name;
+        if (w !== "White" || d !== "Dark") {
+            parts.push(this._sanitizeName(w !== "White" ? w : "White"));
+            parts.push(this._sanitizeName(d !== "Dark" ? d : "Dark"));
+        }
+
+        // Time: startTime if set, else current time
+        const time = this.game.startTime
+            ? this.game.startTime.replace(":", "")
+            : new Date().toTimeString().slice(0, 5).replace(":", "");
+        parts.push(time);
+
+        return parts.join("-") + ".csv";
+    },
+
+    _sanitizeName(name) {
+        return name.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9-]/g, "");
+    },
+
+    _doExport() {
+        if (!this.game) return;
+        const header = "deviceTime,seq,period,time,team,cap,event";
+        const rows = this.game.log.map((e) => {
+            return [
+                e.deviceTime || "",
+                e.seq || "",
+                e.period || "",
+                e.time || "",
+                e.team || "",
+                this._csvEscape(e.cap || ""),
+                this._csvEscape(e.event || ""),
+            ].join(",");
+        });
+        const csv = header + "\n" + rows.join("\n") + "\n";
+        const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = document.getElementById("csv-filename").value || this._buildFilename();
+        a.click();
+        URL.revokeObjectURL(url);
+    },
+
+    _csvEscape(val) {
+        const str = String(val);
+        if (str.includes(",") || str.includes("\"") || str.includes("\n")) {
+            return "\"" + str.replace(/"/g, "\"\"") + "\"";
+        }
+        return str;
     },
 };

--- a/screens/share.html
+++ b/screens/share.html
@@ -20,4 +20,5 @@
 </div>
 <div class="share-buttons">
   <button id="print-sheet-btn" class="btn btn-primary btn-large">Print Game Sheet</button>
+  <button id="export-csv-btn" class="btn btn-primary btn-large">Download CSV</button>
 </div>


### PR DESCRIPTION
- Download CSV button on Share screen (same primary style as Print)
- Click opens dialog with editable filename input (default: wplog-date-teams-time.csv)
- Filename adapts: date + custom team names (if set) + start time (or export time)
- 7 raw columns: deviceTime, seq, period, time, team, cap, event
- Keyboard: Enter downloads, Escape cancels
- Blob-based download (no server needed)
