### PR TITLE
Add USAWP 7-min and 6-min period variants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ These were explicitly discussed and agreed with the user:
 | **Anti-orphan logic** | Tables only start on a page if there's room for title + thead + at least 1 data row. Otherwise flushed to next page. |
 | **Sections start on own pages** | Game Log, Game Summary, and Game Stats each begin on a fresh page. |
 | **Print row height = 18px** | All table cells: `height: 18px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis`. No wrapping allowed in print — ensures pagination math is exact. Log tables use auto column sizing (no `table-layout: fixed`) so headers are never truncated; summary/stats tables use `table-layout: fixed`. |
-| **USAWP + NFHS + NCAA supported** | USAWP, NFHS Varsity (7-min, OT, MAM), NFHS JV (6-min, no OT), NCAA (8-min, OT, YRC). Additional rule sets added via inheritance. |
+| **USAWP + NFHS + NCAA supported** | USAWP (8-min default, 7-min, 6-min variants), NFHS Varsity (7-min, OT, MAM), NFHS JV (6-min, no OT), NCAA (8-min, OT, YRC). Additional rule sets added via inheritance. |
 | **Rule set inheritance** | `inherits` key chains parent→child. `addEvents`/`removeEvents` directives for per-ruleset event list mutations. `_base` and `_academic` are internal (hidden from dropdown). `STATS_EVENTS` auto-appended to all rule sets. |
 | **Cap flags** | `allowCoach`, `allowAssistant`, `allowBench` enable C/AC/B cap values. `allowPlayer` (default true) can be set false to block digit input. `allowNoCap` allows submitting without cap. `teamOnly` (renamed from `noPlayer`) hides cap field entirely. |
 | **No `#` in Cap display** | Cap numbers shown without `#` prefix everywhere (modal, live log, sheet tables). |

--- a/js/config.js
+++ b/js/config.js
@@ -84,6 +84,16 @@ export const RULES = {
         ],
         timeouts: { full: 2, to30: 0 },
     },
+    USAWP7: {
+        inherits: "USAWP",
+        name: "USA Water Polo (7 min)",
+        periodLength: 7,
+    },
+    USAWP6: {
+        inherits: "USAWP",
+        name: "USA Water Polo (6 min)",
+        periodLength: 6,
+    },
     _academic: {
         inherits: "_base",
         periodLength: 7,


### PR DESCRIPTION
Add two new rule sets inheriting from USAWP:
- USAWP7: USA Water Polo (7 min) — 7-minute periods
- USAWP6: USA Water Polo (6 min) — 6-minute periods

Also updates AGENTS.md to document the variants.
