### PR TITLE
Lock post-regulation toggle at game start (#103)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,7 @@ Inherits from `_academic` (8-min periods). Adds:
 
 ### What's Done ✅
 - Complete setup screen (rules, date, time, location, Game #, team names, OT/SO toggles, timeout overrides)
-- Setup guards during active game (disable Start/rules, lock OT/SO if started, red END GAME button)
+- Setup guards during active game (disable Start/rules, lock OT/SO/period config/timeouts/logging mode, red END GAME button)
 - Live-save of editable setup fields during active game
 - Four rule sets: USAWP, NFHS Varsity, NFHS JV, NCAA (via inheritance-based config system)
 - Rule set inheritance: `_base`/`_academic` internal bases, `inherits`, `addEvents`/`removeEvents` directives

--- a/js/setup.js
+++ b/js/setup.js
@@ -110,10 +110,6 @@ export const Setup = {
         // Disable rules change during game
         document.getElementById("setup-rules").disabled = true;
 
-        // Disable OT/SO if that phase has started
-        const hasOT = game.log.some((e) => typeof e.period === "string" && e.period.startsWith("OT"));
-        const hasSO = game.log.some((e) => e.period === "SO");
-
         // Live-save editable fields back to the active game
         const saveField = (id, setter) => {
             document.getElementById(id).addEventListener("change", () => {
@@ -157,15 +153,13 @@ export const Setup = {
 
         this._updateLoggingHeader();
 
-        // Post-regulation — set active and disable
+        // Post-regulation — set active and always disable during active game
         const prValue = game.overtime ? "overtime" : game.shootout ? "shootout" : "none";
         const prControl = document.getElementById("setup-post-regulation");
-        if (hasOT || hasSO) {
-            prControl.classList.add("disabled");
-        }
+        prControl.classList.add("disabled");
         prControl.querySelectorAll(".segment-btn").forEach((btn) => {
             btn.classList.toggle("active", btn.dataset.value === prValue);
-            if (hasOT || hasSO) btn.disabled = true;
+            btn.disabled = true;
         });
 
         // Steppers — set values and disable


### PR DESCRIPTION
Previously, the OT/SO segmented control was only locked when the
OT/SO phase had actually started. Now it's always locked during an
active game, matching the behavior of all other game-affecting
settings (rules, period length, timeouts, logging mode).

Remove unused hasOT/hasSO variables.
