### PR TITLE
feat: add allowOfficial config flag for team-neutral events (#51)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,7 @@ These were explicitly discussed and agreed with the user:
 | **USAWP + NFHS + NCAA supported** | USAWP (8-min default, 7-min, 6-min variants), NFHS Varsity (7-min, OT, MAM), NFHS JV (6-min, no OT), NCAA (8-min, OT, YRC). Additional rule sets added via inheritance. |
 | **Rule set inheritance** | `inherits` key chains parent→child. `addEvents`/`removeEvents` directives for per-ruleset event list mutations. `_base` and `_academic` are internal (hidden from dropdown). `STATS_EVENTS` auto-appended to all rule sets. |
 | **Cap flags** | `allowCoach`, `allowAssistant`, `allowBench` enable C/AC/B cap values. `allowPlayer` (default true) can be set false to block digit input. `allowNoCap` allows submitting without cap. `teamOnly` (renamed from `noPlayer`) hides cap field entirely. |
+| **`allowOfficial` flag** | Config-driven flag (valid on `teamOnly` events only). Shows a third "OFFICIAL" team toggle button in the modal. Selecting it stores `team: ""` — no new team code. TOL counting naturally excludes official timeouts. `O` keyboard shortcut. Button order: WHITE → OFFICIAL → DARK (Dark stays rightmost for muscle memory). |
 | **No `#` in Cap display** | Cap numbers shown without `#` prefix everywhere (modal, live log, sheet tables). |
 | **Score on Goals only** | Score column in game log (live + sheet) only shows on Goal events. Other events leave it empty. |
 | **Responsive modal** | Full-screen on mobile (default), fixed centered dialog on desktop (`@media min-width:900px and min-height:700px`). |
@@ -187,7 +188,7 @@ Inherits from `_academic` (8-min periods). Adds:
 
 ---
 
-## Current State (as of 2026-03-19)
+## Current State (as of 2026-03-20)
 
 ### What's Done ✅
 - Complete setup screen (rules, date, time, location, Game #, team names, OT/SO toggles, timeout overrides)
@@ -207,6 +208,7 @@ Inherits from `_academic` (8-min periods). Adds:
 - Auto-clear time/cap on refocus (user click only, not auto-advance)
 - Event alignment framework (left/right/center per event in config)
 - Cap flags: `allowCoach`, `allowAssistant`, `allowBench`, `allowPlayer` (default true), `allowNoCap`
+- `allowOfficial` flag: third "OFFICIAL" team toggle for team-neutral events (e.g., referee/media timeouts), stores `team: ""`
 - `teamOnly` flag (renamed from `noPlayer`) hides cap field entirely for team-level events
 - Period End / End Game logic (OT/SO aware, score-tie checks)
 - Timeout tracking with configurable limits, TOL display, over-limit warnings

--- a/css/style.css
+++ b/css/style.css
@@ -713,6 +713,16 @@ select.form-input {
   box-shadow: 0 0 16px rgba(245, 158, 11, 0.1);
 }
 
+.team-btn-official {
+  color: var(--text-secondary);
+}
+
+.team-btn-official.active {
+  background: rgba(136, 146, 168, 0.12);
+  border-color: var(--text-secondary);
+  box-shadow: 0 0 16px rgba(136, 146, 168, 0.1);
+}
+
 /* ============================
    Numpad
    ============================ */

--- a/js/config.js
+++ b/js/config.js
@@ -34,6 +34,7 @@ export const APP_VERSION = "dev";
 //   allowBench    — (optional) true to allow "B" (bench) as cap value
 //   allowPlayer   — (optional, default: true) false to block digit cap input (non-player events)
 //   allowNoCap    — (optional) true to allow submitting without a cap number
+//   allowOfficial — (optional) true to allow "Official" team selection (team-neutral; teamOnly events only)
 //
 // Rule sets support inheritance via the `inherits` key:
 //   inherits     — (optional) key of parent rule set; child overrides only what differs
@@ -73,7 +74,7 @@ export const RULES = {
             { name: "Goal", code: "G", color: "green", align: "left" },
             { name: "Exclusion", code: "E", color: "amber", align: "right", isPersonalFoul: true },
             { name: "Penalty", code: "P", color: "amber", align: "right", isPersonalFoul: true },
-            { name: "Timeout", code: "TO", color: "blue", teamOnly: true, align: "center" },
+            { name: "Timeout", code: "TO", color: "blue", teamOnly: true, allowOfficial: true, align: "center" },
             { name: "Timeout 30", code: "TO30", color: "blue", align: "center", teamOnly: true },
             { name: "Yellow Card", code: "YC", color: "yellow", align: "center", allowCoach: true, allowAssistant: false, allowBench: true },
             { name: "Penalty-Exclusion", code: "P-E", color: "amber", align: "right", isPersonalFoul: true },
@@ -107,7 +108,7 @@ export const RULES = {
             { name: "Minor Act", code: "MAM", color: "amber", align: "right", isPersonalFoul: true, autoFoulOut: 2 },
             { name: "Penalty-Exclusion", code: "P-E", color: "amber", align: "right", isPersonalFoul: true },
             { name: "Yellow Card", code: "YC", color: "yellow", align: "center", allowCoach: true, allowAssistant: false, allowBench: true },
-            { name: "Timeout", code: "TO", color: "blue", teamOnly: true, align: "center" },
+            { name: "Timeout", code: "TO", color: "blue", teamOnly: true, allowOfficial: true, align: "center" },
             { name: "Timeout 30", code: "TO30", color: "blue", align: "center", teamOnly: true },
             { name: "Misconduct", code: "MC", color: "red", align: "right", autoFoulOut: 1 },
             { name: "Game Exclusion", code: "E-Game", color: "red", align: "right", autoFoulOut: 1 },

--- a/js/events.js
+++ b/js/events.js
@@ -116,6 +116,7 @@ export const Events = {
         // Team toggle
         document.getElementById("team-white-btn").addEventListener("click", () => this._selectTeam("W"));
         document.getElementById("team-dark-btn").addEventListener("click", () => this._selectTeam("D"));
+        document.getElementById("team-official-btn").addEventListener("click", () => this._selectTeam("official"));
 
         // Field selection — tap to switch numpad target
         document.getElementById("field-time").addEventListener("click", () => this._setNumpadTarget("time", true));
@@ -150,7 +151,7 @@ export const Events = {
                 return;
             }
 
-            // W/D for team selection (case-insensitive)
+            // W/D/O for team selection (case-insensitive)
             if (upper === "W") {
                 e.preventDefault();
                 this._selectTeam("W");
@@ -160,6 +161,17 @@ export const Events = {
                 e.preventDefault();
                 this._selectTeam("D");
                 return;
+            }
+            if (upper === "O") {
+                // Only if allowOfficial is set on this event
+                const oCode = document.getElementById("modal-event-title").dataset.code;
+                const oRules = RULES[this.game.rules];
+                const oEventDef = oRules.events.find((ev) => ev.code === oCode);
+                if (oEventDef && oEventDef.allowOfficial) {
+                    e.preventDefault();
+                    this._selectTeam("official");
+                    return;
+                }
             }
 
             // Backspace = clear
@@ -332,6 +344,13 @@ export const Events = {
         } else {
             capField.style.display = "";
         }
+
+        // Show/hide Official team button
+        const officialBtn = document.getElementById("team-official-btn");
+        if (officialBtn) {
+            officialBtn.style.display = (eventDef && eventDef.allowOfficial) ? "" : "none";
+        }
+
         this._updateOkButton();
     },
 
@@ -384,6 +403,8 @@ export const Events = {
         this.selectedTeam = null;
         document.getElementById("team-white-btn").classList.remove("active");
         document.getElementById("team-dark-btn").classList.remove("active");
+        const officialBtn = document.getElementById("team-official-btn");
+        if (officialBtn) officialBtn.classList.remove("active");
 
         // Update OK state
         this._updateOkButton();
@@ -401,6 +422,8 @@ export const Events = {
         this.selectedTeam = team;
         document.getElementById("team-white-btn").classList.toggle("active", team === "W");
         document.getElementById("team-dark-btn").classList.toggle("active", team === "D");
+        const officialBtn = document.getElementById("team-official-btn");
+        if (officialBtn) officialBtn.classList.toggle("active", team === "official");
         this._updateOkButton();
     },
 
@@ -461,7 +484,7 @@ export const Events = {
         Game.addEvent(this.game, {
             period,
             time,
-            team: this.selectedTeam,
+            team: this.selectedTeam === "official" ? "" : this.selectedTeam,
             cap: eventDef.teamOnly ? "" : cap,
             event: eventDef.code,
             note: "",

--- a/js/sheet.js
+++ b/js/sheet.js
@@ -362,8 +362,9 @@ export const Sheet = {
             const tr = document.createElement("tr");
             const rules = RULES[this.game.rules];
             const eventDef = rules.events.find((e) => e.code === entry.event);
+            const teamDisplay = entry.team === "W" ? "White" : (entry.team === "D" ? "Dark" : (entry.team === "" ? "Official" : "—"));
             tr.innerHTML = `
-        <td>${entry.team === "W" ? "White" : (entry.team === "D" ? "Dark" : "—")}</td>
+        <td>${teamDisplay}</td>
         <td>${Game.getPeriodLabel(entry.period)}</td>
         <td>${entry.time.replace(/^0(\d:)/, '$1')}</td>
         <td>${eventDef ? eventDef.name : entry.event}</td>

--- a/screens/modal.html
+++ b/screens/modal.html
@@ -32,6 +32,7 @@
 <!-- Team Toggle -->
 <div id="modal-team-section" class="team-toggle">
   <button id="team-white-btn" class="team-btn team-btn-white">WHITE</button>
+  <button id="team-official-btn" class="team-btn team-btn-official" style="display:none">OFFICIAL</button>
   <button id="team-dark-btn" class="team-btn team-btn-dark">DARK</button>
 </div>
 


### PR DESCRIPTION
Add support for a third 'OFFICIAL' team toggle button in the event
modal, controlled by the allowOfficial config flag (valid on teamOnly
events only). Selecting Official stores team: '' — no new team code.

- Config: added allowOfficial flag documentation
- Modal: third toggle button (W-O-D order), O keyboard shortcut
- Styling: neutral gray for Official button
- Game sheet: timeout summary shows 'Official' for team-neutral entries
- TOL counting naturally excludes official timeouts (team: '')
