### PR TITLE
Decouple Storage.save() from Game mutation methods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ wplog/
 │   ├── config.js       # APP_VERSION + RULES definitions (USAWP, NFHS Varsity, NFHS JV, NCAA)
 │   ├── confirm.js      # Custom confirmation dialog (replaces native confirm())
 │   ├── storage.js      # localStorage wrapper (with schema validation)
-│   ├── game.js         # Core data model + game logic
+│   ├── game.js         # Core data model + game logic (pure — no Storage dependency)
 │   ├── setup.js        # Setup screen (with active-game guards)
-│   ├── events.js       # Live log screen (main UI)
+│   ├── events.js       # Live log screen (main UI, owns Storage.save after mutations)
 │   ├── sheet.js        # Game sheet orchestrator + shared render helpers
 │   ├── sheet-screen.js # Game sheet screen rendering (2-page DOM layout)
 │   ├── sheet-print.js  # Game sheet print pagination (multi-column, table splitting)
@@ -312,6 +312,7 @@ Inherits from `_academic` (8-min periods). Adds:
 - Service worker registration in `loader.js` with `{ type: 'module' }` — enables offline caching, cache busting via `APP_VERSION`
 - Restart App handler awaits async cleanup (SW unregistration + cache deletion) before reload — fixes race condition
 - Help documentation kept current alongside feature delivery — geronimo and kraken workflows include help.html check steps, bazinga establishes doc-as-delivery principle
+- `Game` decoupled from `Storage`: mutation methods (`addEvent`, `deleteEvent`, `editEvent`, `advancePeriod`) no longer call `Storage.save()` — UI layer (`events.js`) owns persistence
 
 ### Known Gaps / Future Work 📋
 - No substitution tracking (user hasn't decided)

--- a/js/events.js
+++ b/js/events.js
@@ -18,6 +18,7 @@ import { RULES } from './config.js';
 import { ConfirmDialog } from './confirm.js';
 import { Game } from './game.js';
 import { escapeHTML } from './sanitize.js';
+import { Storage } from './storage.js';
 
 // wplog — Live Log Screen (Event Logging)
 // Event-first workflow: tap event button → modal opens → enter details → OK
@@ -489,6 +490,7 @@ export const Events = {
             event: eventDef.code,
             note: "",
         });
+        Storage.save(this.game);
 
         // Close modal
         this._closeModal();
@@ -719,6 +721,7 @@ export const Events = {
                         this.game.currentPeriod = entry.period;
                     }
                     Game.deleteEvent(this.game, id);
+                    Storage.save(this.game);
                     this._updateScoreBar();
                     this._updateLog();
                     this._updateEndButton();
@@ -747,6 +750,7 @@ export const Events = {
             event: "---",
             note,
         });
+        Storage.save(this.game);
 
         if (isEndGame) {
             // Store end time on game object
@@ -758,6 +762,7 @@ export const Events = {
             this._showToast("Game over", "info");
         } else {
             Game.advancePeriod(this.game);
+            Storage.save(this.game);
             this._buildPeriodTabs();
             this._updateScoreBar();
             this._updateLog();

--- a/js/game.js
+++ b/js/game.js
@@ -15,7 +15,6 @@
  */
 
 import { RULES } from './config.js';
-import { Storage } from './storage.js';
 
 // wplog — Game State Management
 
@@ -80,7 +79,6 @@ export const Game = {
         game.log.push(entry);
         this._sortLog(game);
         this._recalcScores(game);
-        Storage.save(game);
         return entry;
     },
 
@@ -88,7 +86,6 @@ export const Game = {
     deleteEvent(game, eventId) {
         game.log = game.log.filter((e) => e.id !== eventId);
         this._recalcScores(game);
-        Storage.save(game);
     },
 
     // Edit an existing event and recalculate scores
@@ -98,7 +95,6 @@ export const Game = {
         Object.assign(entry, updates);
         this._sortLog(game);
         this._recalcScores(game);
-        Storage.save(game);
     },
 
     // Sort events within each period by game time (descending).
@@ -303,7 +299,6 @@ export const Game = {
         const next = this.getNextPeriod(game);
         if (next !== null) {
             game.currentPeriod = next;
-            Storage.save(game);
         }
         return next;
     },


### PR DESCRIPTION
Remove Storage.save() calls from Game.addEvent(), deleteEvent(),
editEvent(), and advancePeriod(). Move persistence responsibility
to the UI layer (events.js), which now owns Storage.save() after
each mutation call.

Game is now a pure data model with no Storage dependency, making
it fully testable without browser localStorage.

Ref #123
