### PR TITLE
Fix cap "0" accepted by validation

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -32,7 +32,7 @@ const MAX_NOTE = 500;
 const RE_DATE = /^\d{4}-\d{2}-\d{2}$/;
 const RE_TIME_HM = /^\d{2}:\d{2}$/;
 const RE_GAME_TIME = /^\d:\d{2}$/;
-const RE_CAP = /^\d{1,2}[ABC]?$/;
+const RE_CAP = /^[1-9]\d?[ABC]?$/;
 const RE_PERIOD_OT = /^OT([1-9]\d?)$/;
 
 // Valid rule keys: public RULES keys that don't start with _

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -404,7 +404,7 @@ describe("validateGameData — cap number validation", () => {
     }
 
     for (const cap of ["100", "0", "1D", "ABC", "1a", "-1"]) {
-        it(`rejects cap "${cap}"`, { todo: "see issue" }, () => {
+        it(`rejects cap "${cap}"`, () => {
             const result = validateGameData(validGame({
                 log: [validGoalEntry({ cap })],
             }));


### PR DESCRIPTION
Tighten RE_CAP from /^\d{1,2}[ABC]?$/ to /^[1-9]\d?[ABC]?$/
so the first digit must be 1-9. Caps 1-99 + goalie modifiers
(1A/1B/1C) + C/AC/B remain valid. Zero is not a valid cap.

Un-todo 6 cap rejection tests that now pass.

Fixes #119
