### PR TITLE
Fix time "0:60" accepted by validation

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -31,7 +31,7 @@ const MAX_NOTE = 500;
 
 const RE_DATE = /^\d{4}-\d{2}-\d{2}$/;
 const RE_TIME_HM = /^\d{2}:\d{2}$/;
-const RE_GAME_TIME = /^\d:\d{2}$/;
+const RE_GAME_TIME = /^\d:[0-5]\d$/;
 const RE_CAP = /^[1-9]\d?[ABC]?$/;
 const RE_PERIOD_OT = /^OT([1-9]\d?)$/;
 

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -426,7 +426,7 @@ describe("validateGameData — game clock time format", () => {
     }
 
     for (const time of ["10:00", "12:00", "1:2", ":30", "abc", "0:60"]) {
-        it(`rejects time "${time}"`, { todo: "see issue" }, () => {
+        it(`rejects time "${time}"`, () => {
             const result = validateGameData(validGame({
                 log: [validGoalEntry({ time })],
             }));


### PR DESCRIPTION
Tighten RE_GAME_TIME from /^\d:\d{2}$/ to /^\d:[0-5]\d$/
so seconds must be 0-59. Multi-digit minutes (10:00, 12:00)
were already rejected by the single-digit minute constraint.

Un-todo 6 time rejection tests that now pass.

Fixes #120
