### PR TITLE
Fix period validation to use rules.periods dynamically

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -137,7 +137,7 @@ export function validateGameData(parsed) {
         }
 
         // currentPeriod
-        if (!_isValidPeriod(parsed.currentPeriod)) {
+        if (!_isValidPeriod(parsed.currentPeriod, resolvedRules.periods)) {
             return _fail("Invalid current period.");
         }
 
@@ -172,7 +172,7 @@ export function validateGameData(parsed) {
             }
 
             // period
-            if (!_isValidPeriod(entry.period)) {
+            if (!_isValidPeriod(entry.period, resolvedRules.periods)) {
                 return _fail(`Log entry ${i + 1}: invalid period.`);
             }
 
@@ -302,8 +302,8 @@ function _isTeamObject(val) {
         _isString(val.name) && val.name.length <= MAX_TEAM_NAME;
 }
 
-function _isValidPeriod(val) {
-    if (_isIntInRange(val, 1, 20)) return true;
+function _isValidPeriod(val, maxPeriod) {
+    if (_isIntInRange(val, 1, maxPeriod)) return true;
     if (_isString(val)) {
         if (val === "SO") return true;
         if (RE_PERIOD_OT.test(val)) return true;

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -449,7 +449,7 @@ describe("validateGameData — period validation", () => {
     }
 
     for (const period of [0, 5, -1, "Q1", "OT", "OT0", "SO1", "overtime"]) {
-        it(`rejects period ${period}`, { todo: "see issue" }, () => {
+        it(`rejects period ${period}`, () => {
             const result = validateGameData(validGame({
                 currentPeriod: period,
             }));


### PR DESCRIPTION
_isValidPeriod now accepts maxPeriod parameter from the resolved
rules config (currently 4 for all rule sets) instead of hardcoded
1-20. Periods 5+ now correctly rejected for integer periods.
OT/SO string periods are unaffected.

Un-todo 8 period rejection tests — full suite now 365/365 pass.

Fixes #121
