### PR TITLE
Extract formatFractionalScore() as pure utility

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -18,6 +18,11 @@ import { RULES } from './config.js';
 
 // wplog — Game State Management
 
+// Pure utility: format a fractional SO score (e.g., "5.3" for 5 total, 3 in SO).
+export function formatFractionalScore(totalScore, soGoals) {
+    return `${totalScore - soGoals}.${soGoals}`;
+}
+
 export const Game = {
     // Create a new game with defaults from rules
     create(rulesKey = "USAWP") {
@@ -168,8 +173,8 @@ export const Game = {
         if (!inSO) return { white: String(score.white), dark: String(score.dark) };
 
         return {
-            white: (score.white - soW) + "." + soW,
-            dark: (score.dark - soD) + "." + soD,
+            white: formatFractionalScore(score.white, soW),
+            dark: formatFractionalScore(score.dark, soD),
         };
     },
 
@@ -179,7 +184,7 @@ export const Game = {
         const soW = game.log.filter(e => e.id <= entry.id && e.event === "G" && e.team === "W" && e.period === "SO").length;
         const soD = game.log.filter(e => e.id <= entry.id && e.event === "G" && e.team === "D" && e.period === "SO").length;
         if (soW === 0 && soD === 0) return entry.scoreW + "–" + entry.scoreD;
-        return (entry.scoreW - soW) + "." + soW + "–" + (entry.scoreD - soD) + "." + soD;
+        return formatFractionalScore(entry.scoreW, soW) + "–" + formatFractionalScore(entry.scoreD, soD);
     },
 
     // Get timeouts used per team

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -14,7 +14,7 @@
 
 import { describe, it } from "node:test";
 import { strictEqual, deepStrictEqual, ok } from "node:assert";
-import { Game } from "../js/game.js";
+import { Game, formatFractionalScore } from "../js/game.js";
 import { RULES } from "../js/config.js";
 
 // All public rule sets — tests iterate over these.
@@ -339,6 +339,30 @@ describe("Game.formatEntryScore", () => {
         Game.addEvent(g, { period: "SO", time: "0:00", team: "W", cap: "9", event: "G" });
         const formatted = Game.formatEntryScore(g.log[1], g);
         strictEqual(formatted, "1.1–0.0");
+    });
+});
+
+// ── formatFractionalScore ─────────────────────────────────────────
+
+describe("formatFractionalScore", () => {
+    it("formats typical SO score", () => {
+        strictEqual(formatFractionalScore(5, 3), "2.3");
+    });
+
+    it("formats zero SO goals", () => {
+        strictEqual(formatFractionalScore(4, 0), "4.0");
+    });
+
+    it("formats all goals from SO", () => {
+        strictEqual(formatFractionalScore(3, 3), "0.3");
+    });
+
+    it("formats single SO goal", () => {
+        strictEqual(formatFractionalScore(7, 1), "6.1");
+    });
+
+    it("formats zero total and zero SO", () => {
+        strictEqual(formatFractionalScore(0, 0), "0.0");
     });
 });
 


### PR DESCRIPTION
Add exported formatFractionalScore(totalScore, soGoals) function
to game.js. Refactor getDisplayScore() and formatEntryScore() to
call it instead of inlining the (total - so) + '.' + so pattern.

Add 5 direct unit tests for the new function.

Fixes #124
