### PR TITLE
Extract CSV/filename builders into pure export.js module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ wplog/
 │   ├── sheet-screen.js # Game sheet screen rendering (2-page DOM layout)
 │   ├── sheet-print.js  # Game sheet print pagination (multi-column, table splitting)
 │   ├── share.js        # Share/Print functionality
+│   ├── export.js       # Export utilities — filename, CSV builders (pure — no DOM)
 │   └── app.js          # App init + screen navigation + version display
 ├── help.html           # Standalone help page (uses standalone.css)
 ├── sw.js               # Service worker (offline caching, version-keyed cache)

--- a/js/export.js
+++ b/js/export.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2026 Marko Milivojevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// wplog — Export Utilities (pure, no DOM)
+
+/**
+ * Sanitize a name for use in filenames.
+ * Replaces whitespace with hyphens, strips non-alphanumeric characters.
+ */
+export function sanitizeName(name) {
+    return name.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9-]/g, "");
+}
+
+/**
+ * Build an export filename from game metadata.
+ * Format: wplog-DATE[-TEAM1-TEAM2]-TIME.ext
+ * @param {object} game - Game data object
+ * @param {string} ext - File extension including dot (e.g., ".csv")
+ * @returns {string} Filename
+ */
+export function buildFilename(game, ext) {
+    const parts = ["wplog"];
+
+    // Date
+    const date = game.date || new Date().toISOString().slice(0, 10);
+    parts.push(date);
+
+    // Teams (only if custom)
+    const w = game.white.name;
+    const d = game.dark.name;
+    if (w !== "White" || d !== "Dark") {
+        parts.push(sanitizeName(w !== "White" ? w : "White"));
+        parts.push(sanitizeName(d !== "Dark" ? d : "Dark"));
+    }
+
+    // Time: startTime if set, else current time
+    const time = game.startTime
+        ? game.startTime.replace(":", "")
+        : new Date().toTimeString().slice(0, 5).replace(":", "");
+    parts.push(time);
+
+    return parts.join("-") + ext;
+}
+
+/**
+ * Escape a value for CSV (RFC 4180).
+ * Quotes the value if it contains commas, double quotes, or newlines.
+ */
+export function csvEscape(val) {
+    const str = String(val);
+    if (str.includes(",") || str.includes("\"") || str.includes("\n")) {
+        return "\"" + str.replace(/"/g, "\"\"") + "\"";
+    }
+    return str;
+}
+
+/**
+ * Build complete CSV content from a game's log.
+ * @param {object} game - Game data object
+ * @returns {string} CSV string with header and trailing newline
+ */
+export function buildCSV(game) {
+    const header = "deviceTime,seq,period,time,team,cap,event";
+    const rows = game.log.map((e) => {
+        return [
+            e.deviceTime || "",
+            e.seq || "",
+            e.period || "",
+            e.time || "",
+            e.team || "",
+            csvEscape(e.cap || ""),
+            csvEscape(e.event || ""),
+        ].join(",");
+    });
+    return header + "\n" + rows.join("\n") + "\n";
+}

--- a/js/share.js
+++ b/js/share.js
@@ -15,6 +15,7 @@
  */
 
 import { Sheet } from './sheet.js';
+import { buildFilename, buildCSV } from './export.js';
 
 // wplog — Share / Print / Export
 
@@ -132,7 +133,7 @@ export const Share = {
         const ext = format === "json" ? ".json" : ".csv";
         document.getElementById("download-title").textContent = title;
         const input = document.getElementById("download-filename");
-        input.value = this._buildFilename(ext);
+        input.value = buildFilename(this.game, ext);
         document.getElementById("download-overlay").classList.add("visible");
         input.focus();
         input.select();
@@ -152,36 +153,6 @@ export const Share = {
         }
     },
 
-    // ── Filename Builder ────────────────────────────────────
-
-    _buildFilename(ext) {
-        const parts = ["wplog"];
-
-        // Date
-        const date = this.game.date || new Date().toISOString().slice(0, 10);
-        parts.push(date);
-
-        // Teams (only if custom)
-        const w = this.game.white.name;
-        const d = this.game.dark.name;
-        if (w !== "White" || d !== "Dark") {
-            parts.push(this._sanitizeName(w !== "White" ? w : "White"));
-            parts.push(this._sanitizeName(d !== "Dark" ? d : "Dark"));
-        }
-
-        // Time: startTime if set, else current time
-        const time = this.game.startTime
-            ? this.game.startTime.replace(":", "")
-            : new Date().toTimeString().slice(0, 5).replace(":", "");
-        parts.push(time);
-
-        return parts.join("-") + ext;
-    },
-
-    _sanitizeName(name) {
-        return name.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9-]/g, "");
-    },
-
     // ── JSON Export ─────────────────────────────────────────
 
     _doDownloadJSON() {
@@ -195,29 +166,9 @@ export const Share = {
 
     _doDownloadCSV() {
         if (!this.game) return;
-        const header = "deviceTime,seq,period,time,team,cap,event";
-        const rows = this.game.log.map((e) => {
-            return [
-                e.deviceTime || "",
-                e.seq || "",
-                e.period || "",
-                e.time || "",
-                e.team || "",
-                this._csvEscape(e.cap || ""),
-                this._csvEscape(e.event || ""),
-            ].join(",");
-        });
-        const csv = header + "\n" + rows.join("\n") + "\n";
+        const csv = buildCSV(this.game);
         const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
         this._downloadBlob(blob, "download-filename");
-    },
-
-    _csvEscape(val) {
-        const str = String(val);
-        if (str.includes(",") || str.includes("\"") || str.includes("\n")) {
-            return "\"" + str.replace(/"/g, "\"\"") + "\"";
-        }
-        return str;
     },
 
     // ── Shared Download Helper ──────────────────────────────

--- a/sw.js
+++ b/sw.js
@@ -39,6 +39,7 @@ const ASSETS = [
     "./js/sheet-print.js",
     "./js/share.js",
     "./js/app.js",
+    "./js/export.js",
     "./img/qr-wplog.svg",
     "./img/favicon-32.png",
     "./img/favicon-192.png",

--- a/tests/export.test.js
+++ b/tests/export.test.js
@@ -1,0 +1,158 @@
+// Copyright 2026 Marko Milivojevic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it } from "node:test";
+import { strictEqual, ok } from "node:assert";
+import { sanitizeName, buildFilename, csvEscape, buildCSV } from "../js/export.js";
+
+// ── sanitizeName ─────────────────────────────────────────────
+
+describe("sanitizeName", () => {
+    it("passes through simple names", () => {
+        strictEqual(sanitizeName("Tigers"), "Tigers");
+    });
+
+    it("replaces spaces with hyphens", () => {
+        strictEqual(sanitizeName("LA Water Polo"), "LA-Water-Polo");
+    });
+
+    it("strips special characters", () => {
+        strictEqual(sanitizeName("Team (A) #1!"), "Team-A-1");
+    });
+
+    it("handles empty string", () => {
+        strictEqual(sanitizeName(""), "");
+    });
+
+    it("collapses multiple spaces", () => {
+        strictEqual(sanitizeName("Big   Gap"), "Big-Gap");
+    });
+});
+
+// ── buildFilename ────────────────────────────────────────────
+
+describe("buildFilename", () => {
+    it("builds filename with default teams", () => {
+        const game = {
+            date: "2024-06-15",
+            startTime: "10:00",
+            white: { name: "White" },
+            dark: { name: "Dark" },
+        };
+        strictEqual(buildFilename(game, ".csv"), "wplog-2024-06-15-1000.csv");
+    });
+
+    it("includes custom team names", () => {
+        const game = {
+            date: "2024-06-15",
+            startTime: "14:30",
+            white: { name: "Tigers" },
+            dark: { name: "Sharks" },
+        };
+        strictEqual(buildFilename(game, ".csv"), "wplog-2024-06-15-Tigers-Sharks-1430.csv");
+    });
+
+    it("includes only custom white team (dark default)", () => {
+        const game = {
+            date: "2024-06-15",
+            startTime: "10:00",
+            white: { name: "Eagles" },
+            dark: { name: "Dark" },
+        };
+        strictEqual(buildFilename(game, ".json"), "wplog-2024-06-15-Eagles-Dark-1000.json");
+    });
+
+    it("sanitizes team names in filename", () => {
+        const game = {
+            date: "2024-06-15",
+            startTime: "10:00",
+            white: { name: "LA Water Polo" },
+            dark: { name: "Team #2" },
+        };
+        strictEqual(buildFilename(game, ".csv"), "wplog-2024-06-15-LA-Water-Polo-Team-2-1000.csv");
+    });
+
+    it("uses .json extension", () => {
+        const game = {
+            date: "2024-06-15",
+            startTime: "10:00",
+            white: { name: "White" },
+            dark: { name: "Dark" },
+        };
+        ok(buildFilename(game, ".json").endsWith(".json"));
+    });
+});
+
+// ── csvEscape ────────────────────────────────────────────────
+
+describe("csvEscape", () => {
+    it("returns simple values unchanged", () => {
+        strictEqual(csvEscape("hello"), "hello");
+    });
+
+    it("quotes values with commas", () => {
+        strictEqual(csvEscape("a,b"), '"a,b"');
+    });
+
+    it("escapes and quotes double quotes", () => {
+        strictEqual(csvEscape('say "hi"'), '"say ""hi"""');
+    });
+
+    it("quotes values with newlines", () => {
+        strictEqual(csvEscape("line1\nline2"), '"line1\nline2"');
+    });
+
+    it("handles empty string", () => {
+        strictEqual(csvEscape(""), "");
+    });
+
+    it("converts numbers to strings", () => {
+        strictEqual(csvEscape(42), "42");
+    });
+});
+
+// ── buildCSV ─────────────────────────────────────────────────
+
+describe("buildCSV", () => {
+    it("produces header + rows for a game log", () => {
+        const game = {
+            log: [
+                { deviceTime: "2024-06-15T10:05:00.000Z", seq: 10, period: 1, time: "7:32", team: "W", cap: "7", event: "G" },
+                { deviceTime: "2024-06-15T10:06:00.000Z", seq: 20, period: 1, time: "6:00", team: "D", cap: "3", event: "E" },
+            ],
+        };
+        const csv = buildCSV(game);
+        const lines = csv.split("\n");
+        strictEqual(lines[0], "deviceTime,seq,period,time,team,cap,event");
+        strictEqual(lines[1], "2024-06-15T10:05:00.000Z,10,1,7:32,W,7,G");
+        strictEqual(lines[2], "2024-06-15T10:06:00.000Z,20,1,6:00,D,3,E");
+        strictEqual(lines[3], ""); // trailing newline
+    });
+
+    it("produces header only for empty log", () => {
+        const game = { log: [] };
+        const csv = buildCSV(game);
+        strictEqual(csv, "deviceTime,seq,period,time,team,cap,event\n\n");
+    });
+
+    it("escapes caps and events with special characters", () => {
+        const game = {
+            log: [
+                { deviceTime: "", seq: 10, period: 1, time: "5:00", team: "W", cap: "1A", event: "Field Block" },
+            ],
+        };
+        const csv = buildCSV(game);
+        ok(csv.includes("1A,Field Block"));
+    });
+});


### PR DESCRIPTION
Move sanitizeName, buildFilename, csvEscape, and buildCSV from
share.js into new js/export.js. share.js now imports these pure
functions instead of using inline _buildFilename, _sanitizeName,
_csvEscape, and _doDownloadCSV methods.

Add export.js to SW precache list. Add 19 unit tests.

Fixes #128
