### PR TITLE
Extract pagination engine + stateless Sheet (#126)

### DIFF
--- a/.agents/skills/browser-testing/SKILL.md
+++ b/.agents/skills/browser-testing/SKILL.md
@@ -71,6 +71,7 @@ See [patterns.md](references/patterns.md) for detailed examples covering screen 
 - **Screen HTML**: Fetch from `/screens/<name>.html` and inject into sandbox. Do not copy HTML into tests.
 - **Async everything**: Screen HTML fetching and dynamic imports are async. All test callbacks should be `async`.
 - **No test data files**: Game state comes from `Game.create()` + `Game.addEvent()`, not `testdata/*.json`.
+- **Never trigger `window.print()`**: Do not click Print buttons or call `window.print()` via browser automation. It opens a native OS dialog that the agent cannot dismiss, causing a timeout. Verify print rendering by inspecting the DOM after `Sheet.render(game, paperSize)` — the print layout is built as regular DOM elements before `window.print()` is called.
 
 ## Checklist for Adding a Test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,11 @@ wplog/
 │   ├── game.js         # Core data model + game logic (pure — no Storage dependency)
 │   ├── setup.js        # Setup screen (with active-game guards)
 │   ├── events.js       # Live log screen (main UI, owns Storage.save after mutations)
-│   ├── sheet.js        # Game sheet orchestrator + shared render helpers
+│   ├── sheet.js        # Game sheet orchestrator + shared render helpers (stateless — no stored game)
 │   ├── sheet-data.js   # Sheet data builders (pure — no DOM)
 │   ├── sheet-screen.js # Game sheet screen rendering (2-page DOM layout)
-│   ├── sheet-print.js  # Game sheet print pagination (multi-column, table splitting)
+│   ├── sheet-print.js  # Game sheet print rendering (DOM only — renders from pagination plans)
+│   ├── pagination.js   # Print pagination engine (pure — no DOM)
 │   ├── share.js        # Share/Print functionality
 │   ├── export.js       # Export utilities — filename, CSV builders (pure — no DOM)
 │   └── app.js          # App init + screen navigation + version display
@@ -317,6 +318,9 @@ Inherits from `_academic` (8-min periods). Adds:
 - `Game` decoupled from `Storage`: mutation methods (`addEvent`, `deleteEvent`, `editEvent`, `advancePeriod`) no longer call `Storage.save()` — UI layer (`events.js`) owns persistence
 - Score formatting extracted: `formatFractionalScore()` exported from `game.js` as a pure utility
 - Sheet data builders extracted: `sheet-data.js` exports pure functions (`buildPeriodScores`, `buildPersonalFoulTable`, `buildTimeoutSummary`, `buildCardSummary`, `buildPlayerStats`) — `sheet.js` render methods are thin DOM wrappers
+- Pagination engine extracted: `pagination.js` exports pure functions (`filterLogEvents`, `buildLogPagePlan`, `buildSummaryDescriptors`, `buildStatsDescriptors`, `paginateItems`, `availableRows`) — all print layout math with zero DOM dependency
+- Stateless Sheet: `Sheet.game` removed, `Sheet.init()` replaced with `Sheet.render(game, paperSize)` — all render methods accept `game` as parameter
+- `sheet-print.js` refactored to DOM-only rendering layer — consumes pagination plans from `pagination.js`, no pagination arithmetic
 
 ### Known Gaps / Future Work 📋
 - No substitution tracking (user hasn't decided)

--- a/js/app.js
+++ b/js/app.js
@@ -247,7 +247,7 @@ export const App = {
         document.getElementById("nav-sheet").addEventListener("click", () => {
             if (this.game) {
                 this.showScreen("sheet");
-                Sheet.init(this.game);
+                Sheet.render(this.game);
             }
         });
 
@@ -386,7 +386,7 @@ export const App = {
             case "sheet":
                 if (this.game) {
                     this.showScreen("sheet");
-                    Sheet.init(this.game);
+                    Sheet.render(this.game);
                 } else {
                     this.showScreen("setup");
                 }

--- a/js/pagination.js
+++ b/js/pagination.js
@@ -1,0 +1,338 @@
+/**
+ * Copyright 2026 Marko Milivojevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// wplog — Print Pagination Engine (pure — no DOM)
+//
+// All print layout math lives here: page capacity, column counts,
+// event filtering, row-count descriptors, and generic pagination.
+// Zero DOM dependency — fully testable with node --test.
+
+import { RULES } from './config.js';
+import { Game } from './game.js';
+import {
+    buildPeriodScores,
+    buildPersonalFoulTable,
+    buildTimeoutSummary,
+    buildCardSummary,
+    buildPlayerStats,
+} from './sheet-data.js';
+
+// ── Constants ────────────────────────────────────────────────
+
+// Row-based print constants (all measurements in 18px rows).
+export const ROW_HEIGHT = 18;
+
+// Measured header: title(26) + meta(94) + teams(40) + gaps(32) = 192px
+// 192/18 = 10.67 → round up to 11, plus 1 row spacing = 12.
+export const HEADER_ROWS = 12;
+
+export const PAGE_ROWS = { letter: 52, a4: 56 };
+
+/**
+ * Available content rows per page (total rows minus header).
+ * @param {string} paperSize - "letter" or "a4"
+ * @returns {number}
+ */
+export function availableRows(paperSize) {
+    return PAGE_ROWS[paperSize] - HEADER_ROWS;
+}
+
+// ── Log Event Filtering ─────────────────────────────────────
+
+/**
+ * Filter out statsOnly events from the game log.
+ * Keeps regular events and period-end markers ("---").
+ * @param {Array} log - Game log entries
+ * @param {object} rules - Resolved rules object (from RULES[key])
+ * @returns {Array} Filtered log entries
+ */
+export function filterLogEvents(log, rules) {
+    return log.filter((entry) => {
+        if (entry.event === "---") return true;
+        const eventDef = rules.events.find((e) => e.code === entry.event);
+        return !eventDef || !eventDef.statsOnly;
+    });
+}
+
+// ── Log Page Plan ────────────────────────────────────────────
+
+/** Maximum columns per page in game log layout */
+const MAX_LOG_COLS = 3;
+
+/**
+ * Build a pagination plan for multi-column game log layout.
+ * Each page fills up to MAX_LOG_COLS columns of rowsPerColumn rows.
+ *
+ * @param {number} eventCount - Total number of log events to paginate
+ * @param {number} availRows - Available rows per page
+ * @returns {Array<{startIndex: number, endIndex: number, colCount: number}>}
+ */
+export function buildLogPagePlan(eventCount, availRows) {
+    if (eventCount === 0) return [];
+
+    // Each column needs 1 row for thead
+    const rowsPerColumn = availRows - 1;
+    if (rowsPerColumn <= 0) return [];
+
+    const slotsPerPage = rowsPerColumn * MAX_LOG_COLS;
+    const pages = [];
+
+    for (let i = 0; i < eventCount; i += slotsPerPage) {
+        const chunkSize = Math.min(eventCount - i, slotsPerPage);
+        const colCount = Math.min(Math.ceil(chunkSize / rowsPerColumn), MAX_LOG_COLS);
+        pages.push({
+            startIndex: i,
+            endIndex: i + chunkSize,
+            colCount,
+        });
+    }
+
+    return pages;
+}
+
+// ── Summary Descriptors ──────────────────────────────────────
+
+/**
+ * Build row-count descriptors for Game Summary section items.
+ * Uses sheet-data builders to compute data, then counts rows.
+ * Pure — no DOM.
+ *
+ * @param {object} game - Game data object
+ * @returns {Array<{type: string, titleRows: number, theadRows: number, dataRows: number}>}
+ */
+export function buildSummaryDescriptors(game) {
+    const descriptors = [];
+
+    // Period Scores: title(1) + thead has 1 row in the tr but spans team label row = 1 thead row + 2 data rows
+    const periodData = buildPeriodScores(game);
+    descriptors.push({
+        type: "periodScores",
+        titleRows: 1,
+        theadRows: 1,
+        dataRows: 2, // White row + Dark row
+        data: periodData,
+    });
+
+    // Personal Fouls
+    const foulData = buildPersonalFoulTable(game);
+    if (foulData.length > 0) {
+        descriptors.push({
+            type: "fouls",
+            titleRows: 1,
+            theadRows: 1,
+            dataRows: foulData.length,
+            data: foulData,
+        });
+    } else {
+        descriptors.push({
+            type: "fouls",
+            titleRows: 1,
+            theadRows: 0,
+            dataRows: 1, // "No personal fouls recorded." message
+            data: foulData,
+        });
+    }
+
+    // Timeouts
+    const toData = buildTimeoutSummary(game);
+    if (toData.length > 0) {
+        descriptors.push({
+            type: "timeouts",
+            titleRows: 1,
+            theadRows: 1,
+            dataRows: toData.length,
+            data: toData,
+        });
+    } else {
+        descriptors.push({
+            type: "timeouts",
+            titleRows: 1,
+            theadRows: 0,
+            dataRows: 1,
+            data: toData,
+        });
+    }
+
+    // Cards
+    const cardData = buildCardSummary(game);
+    if (cardData.length > 0) {
+        descriptors.push({
+            type: "cards",
+            titleRows: 1,
+            theadRows: 1,
+            dataRows: cardData.length,
+            data: cardData,
+        });
+    } else {
+        descriptors.push({
+            type: "cards",
+            titleRows: 1,
+            theadRows: 0,
+            dataRows: 1,
+            data: cardData,
+        });
+    }
+
+    return descriptors;
+}
+
+// ── Stats Descriptors ────────────────────────────────────────
+
+/**
+ * Build row-count descriptors for Player Stats section items.
+ * Pure — no DOM.
+ *
+ * @param {object} game - Game data object
+ * @returns {Array<{type: string, code: string, name: string, titleRows: number, theadRows: number, dataRows: number}>}
+ */
+export function buildStatsDescriptors(game) {
+    const statsData = buildPlayerStats(game);
+    if (!statsData) return [];
+
+    const descriptors = [];
+    for (const st of statsData.statTypes) {
+        const wCaps = Object.keys(statsData.stats[st.code].W);
+        const dCaps = Object.keys(statsData.stats[st.code].D);
+        if (wCaps.length === 0 && dCaps.length === 0) continue;
+
+        descriptors.push({
+            type: "stats",
+            code: st.code,
+            name: st.name,
+            titleRows: 1,
+            theadRows: 2, // team headers row + column headers row
+            dataRows: Math.max(wCaps.length, dCaps.length),
+            // Carry rendering data so the DOM layer doesn't need to recompute
+            statsData,
+        });
+    }
+
+    return descriptors;
+}
+
+// ── Generic Pagination ───────────────────────────────────────
+
+/**
+ * Paginate an array of row-count descriptors across pages.
+ * Handles anti-orphan logic and table splitting with "continued" markers.
+ * Pure arithmetic — no DOM.
+ *
+ * Each descriptor has: { titleRows, theadRows, dataRows }
+ * - titleRows: rows for the section title (usually 1)
+ * - theadRows: rows for the table header (0 if no table, e.g. empty message)
+ * - dataRows: number of data rows (or 1 for empty message)
+ *
+ * Returns an array of pages, each with items that reference the original
+ * descriptor by index and specify which data rows to render:
+ *   { index, startRow, endRow, continued }
+ *
+ * @param {Array<{titleRows: number, theadRows: number, dataRows: number}>} descriptors
+ * @param {number} availRows - Available rows per page
+ * @returns {Array<{items: Array<{index: number, startRow: number, endRow: number, continued: boolean}>}>}
+ */
+export function paginateItems(descriptors, availRows) {
+    const pages = [];
+    let currentItems = [];
+    let usedRows = 0;
+
+    const flushPage = () => {
+        if (currentItems.length > 0) {
+            pages.push({ items: currentItems });
+            currentItems = [];
+            usedRows = 0;
+        }
+    };
+
+    for (let idx = 0; idx < descriptors.length; idx++) {
+        const desc = descriptors[idx];
+        const totalRows = desc.titleRows + desc.theadRows + desc.dataRows;
+
+        // 1-row spacing between items on the same page
+        const spacing = currentItems.length > 0 ? 1 : 0;
+
+        // Non-splittable item (no thead = empty message, or small enough)
+        if (desc.theadRows === 0) {
+            if (usedRows + spacing + totalRows > availRows) flushPage();
+            else usedRows += spacing;
+            currentItems.push({
+                index: idx,
+                startRow: 0,
+                endRow: desc.dataRows,
+                continued: false,
+            });
+            usedRows += totalRows;
+            continue;
+        }
+
+        // Does it fit entirely on current page?
+        if (usedRows + spacing + totalRows <= availRows) {
+            usedRows += spacing;
+            currentItems.push({
+                index: idx,
+                startRow: 0,
+                endRow: desc.dataRows,
+                continued: false,
+            });
+            usedRows += totalRows;
+            continue;
+        }
+
+        // Anti-orphan: need at least title + thead + 1 data row to start
+        const overhead = desc.titleRows + desc.theadRows;
+        const minToStart = spacing + overhead + 1;
+        if (availRows - usedRows < minToStart) {
+            flushPage();
+        } else {
+            usedRows += spacing;
+        }
+
+        // Split table across pages
+        let rowIdx = 0;
+        let isFirstChunk = true;
+        while (rowIdx < desc.dataRows) {
+            const space = availRows - usedRows;
+
+            // Anti-orphan: need overhead + at least 1 data row
+            if (space < overhead + 1) {
+                flushPage();
+                continue;
+            }
+
+            const dataFit = space - overhead;
+            const end = Math.min(rowIdx + dataFit, desc.dataRows);
+
+            currentItems.push({
+                index: idx,
+                startRow: rowIdx,
+                endRow: end,
+                continued: !isFirstChunk,
+            });
+            usedRows += overhead + (end - rowIdx);
+            rowIdx = end;
+            isFirstChunk = false;
+
+            if (rowIdx < desc.dataRows) {
+                flushPage();
+            }
+        }
+    }
+
+    if (currentItems.length > 0) {
+        pages.push({ items: currentItems });
+    }
+    if (pages.length === 0) pages.push({ items: [] });
+    return pages;
+}

--- a/js/share.js
+++ b/js/share.js
@@ -111,7 +111,7 @@ export const Share = {
     _doPrint() {
         if (!this.game) return;
         this._setPageSize(this._paperSize);
-        Sheet.init(this.game, this._paperSize);
+        Sheet.render(this.game, this._paperSize);
         window.print();
     },
 

--- a/js/sheet-print.js
+++ b/js/sheet-print.js
@@ -14,60 +14,51 @@
  * limitations under the License.
  */
 
-// wplog — Game Sheet Print Pagination
-// Multi-column log layout, row-based pagination, table splitting,
-// anti-orphan logic, and "continued" headers for printed game sheets.
+// wplog — Game Sheet Print Rendering (DOM only)
+//
+// Renders print-ready DOM from pagination plans produced by pagination.js.
+// No pagination logic here — just DOM construction from plans + data.
 
-import { RULES } from './config.js';
 import { Game } from './game.js';
 import { escapeHTML } from './sanitize.js';
 
-// ── Game Log pagination (multi-column) ───────────────────────
+// ── Game Log rendering ───────────────────────────────────────
 
-export function buildLogPages(sheet, availRows) {
-    const rules = RULES[sheet.game.rules];
-
-    // Filter out statsOnly events from the official game log
-    const logEntries = sheet.game.log.filter((entry) => {
-        if (entry.event === "---") return true;
-        const eventDef = rules.events.find((e) => e.code === entry.event);
-        return !eventDef || !eventDef.statsOnly;
-    });
-
-    if (logEntries.length === 0) {
+/**
+ * Render game log pages from a pagination plan.
+ * @param {Array<{startIndex, endIndex, colCount}>} logPlan - From buildLogPagePlan()
+ * @param {Array} filteredEvents - Pre-filtered log events (no statsOnly)
+ * @param {object} game - Game data
+ * @param {object} rules - Resolved rules object
+ * @param {number} availRows - Available rows per page
+ * @returns {Array<{elements: Array<Element>}>}
+ */
+export function renderLogPages(logPlan, filteredEvents, game, rules, availRows) {
+    if (filteredEvents.length === 0) {
         const empty = document.createElement("p");
         empty.className = "sheet-empty";
         empty.textContent = "No events recorded.";
         return [{ elements: [empty] }];
     }
 
-    // Each column needs 1 row for thead
-    const rowsPerColumn = availRows - 1;
-    if (rowsPerColumn <= 0) return [{ elements: [] }];
+    if (logPlan.length === 0) return [{ elements: [] }];
 
-    // Up to 3 columns per page; grid always uses 3 for consistent widths
+    const rowsPerColumn = availRows - 1; // 1 row for thead per column
     const maxCols = 3;
-    const slotsPerPage = rowsPerColumn * maxCols;
 
-    // Split events into page-sized chunks
-    const pages = [];
-    for (let i = 0; i < logEntries.length; i += slotsPerPage) {
-        const chunk = logEntries.slice(i, i + slotsPerPage);
-        const colCount = Math.min(Math.ceil(chunk.length / rowsPerColumn), maxCols);
-        pages.push({
-            elements: [renderMultiColumnLog(sheet, chunk, rowsPerColumn, colCount, maxCols)],
-        });
-    }
-    return pages;
+    return logPlan.map((chunk) => {
+        const events = filteredEvents.slice(chunk.startIndex, chunk.endIndex);
+        return {
+            elements: [_renderMultiColumnLog(events, chunk.colCount, maxCols, rowsPerColumn, game, rules)],
+        };
+    });
 }
 
-function renderMultiColumnLog(sheet, events, rowsPerColumn, colCount, gridCols) {
-    const rules = RULES[sheet.game.rules];
+function _renderMultiColumnLog(events, colCount, gridCols, rowsPerColumn, game, rules) {
     const wrapper = document.createElement("div");
     wrapper.className = "sheet-log-columns";
     wrapper.style.gridTemplateColumns = `repeat(${gridCols}, 1fr)`;
 
-    // Column-first fill: first rowsPerColumn events → col 1, etc.
     for (let c = 0; c < colCount; c++) {
         const start = c * rowsPerColumn;
         const colEvents = events.slice(start, start + rowsPerColumn);
@@ -106,7 +97,7 @@ function renderMultiColumnLog(sheet, events, rowsPerColumn, colCount, gridCols) 
                     <td>${escapeHTML(entry.cap || "—")}</td>
                     <td>${escapeHTML(entry.team || "—")}</td>
                     <td style="text-align:${align}">${escapeHTML(entry.event)}</td>
-                    <td>${escapeHTML(Game.formatEntryScore(entry, sheet.game))}</td>
+                    <td>${escapeHTML(Game.formatEntryScore(entry, game))}</td>
                 `;
             }
             tbody.appendChild(tr);
@@ -118,228 +109,340 @@ function renderMultiColumnLog(sheet, events, rowsPerColumn, colCount, gridCols) 
     return wrapper;
 }
 
-// ── Summary / Stats pagination ───────────────────────────────
+// ── Summary rendering ────────────────────────────────────────
 
-export function buildSummaryItems(sheet) {
-    const items = [];
+// Section renderers: data → DOM element. One per summary descriptor type.
+const SUMMARY_RENDERERS = {
+    periodScores: _renderPeriodScoresSection,
+    fouls: _renderFoulSection,
+    timeouts: _renderTimeoutSection,
+    cards: _renderCardSection,
+};
 
-    // Period Scores: title(1) + thead(2) + 2 data rows = 5
-    const periodScoresEl = sheet._renderPeriodScores();
-    const periodScoresRows = 1 + 2 + 2; // title + thead + data
-    items.push({ el: periodScoresEl, rows: periodScoresRows });
-
-    // Personal Fouls: title(1) + thead(1) + data
-    const foulEl = sheet._renderFoulSummary();
-    const foulTable = foulEl.querySelector("table");
-    if (foulTable) {
-        const foulDataRows = foulTable.querySelector("tbody").children.length;
-        items.push({ el: foulEl, rows: 1 + 1 + foulDataRows }); // title + thead + data
-    } else {
-        items.push({ el: foulEl, rows: 2 }); // title + empty message
-    }
-
-    // Timeouts: title(1) + thead(1) + data
-    const toEl = sheet._renderTimeoutSummary();
-    const toTable = toEl.querySelector("table");
-    if (toTable) {
-        const toDataRows = toTable.querySelector("tbody").children.length;
-        items.push({ el: toEl, rows: 1 + 1 + toDataRows }); // title + thead + data
-    } else {
-        items.push({ el: toEl, rows: 2 });
-    }
-
-    // Cards: title(1) + thead(1) + data
-    const cardEl = sheet._renderCardSummary();
-    const cardTable = cardEl.querySelector("table");
-    if (cardTable) {
-        const cardDataRows = cardTable.querySelector("tbody").children.length;
-        items.push({ el: cardEl, rows: 1 + 1 + cardDataRows }); // title + thead + data
-    } else {
-        items.push({ el: cardEl, rows: 2 });
-    }
-
-    return items;
+/**
+ * Render Game Summary pages from a pagination plan + descriptors.
+ * @param {Array<{items: Array}>} plan - From paginateItems()
+ * @param {Array} descriptors - From buildSummaryDescriptors() — each has .data
+ * @param {object} game - Game data (unused, reserved for future use)
+ * @returns {Array<{elements: Array<Element>}>}
+ */
+export function renderSummaryPages(plan, descriptors, game) {
+    return _renderPaginatedPages(plan, descriptors, SUMMARY_RENDERERS);
 }
 
-export function buildStatsItems(sheet) {
-    const rules = RULES[sheet.game.rules];
-    const items = [];
+// ── Stats rendering ──────────────────────────────────────────
 
-    const statTypes = rules.events
-        .filter((e) => !e.teamOnly)
-        .map((e) => {
-            const n = e.name;
-            const plural = n.endsWith("y") ? n.slice(0, -1) + "ies" : n + "s";
-            return { code: e.code, name: plural };
-        });
-
-    // Get ordered periods
-    const periodOrder = [];
-    const periodSeen = new Set();
-    for (const entry of sheet.game.log) {
-        if (entry.event === "---") continue;
-        if (!periodSeen.has(entry.period)) {
-            periodSeen.add(entry.period);
-            periodOrder.push(entry.period);
+/**
+ * Render Player Stats pages from a pagination plan + descriptors.
+ * Each descriptor carries .statsData from buildStatsDescriptors().
+ * @param {Array<{items: Array}>} plan - From paginateItems()
+ * @param {Array} descriptors - From buildStatsDescriptors() — each has .statsData
+ * @param {object} game - Game data (unused, reserved for future use)
+ * @returns {Array<{elements: Array<Element>}>}
+ */
+export function renderStatsPages(plan, descriptors, game) {
+    return plan.map((page) => {
+        const elements = [];
+        for (const item of page.items) {
+            const desc = descriptors[item.index];
+            const el = _renderStatTypeFromDescriptor(desc, item);
+            elements.push(el);
         }
-    }
-
-    // Collect counts: counts[code][team][cap][period] = count
-    const counts = {};
-    for (const st of statTypes) {
-        counts[st.code] = { W: {}, D: {} };
-    }
-    for (const entry of sheet.game.log) {
-        if (!entry.cap || !entry.team) continue;
-        if (!counts[entry.event]) continue;
-        const teamData = counts[entry.event][entry.team];
-        if (!teamData[entry.cap]) teamData[entry.cap] = {};
-        teamData[entry.cap][entry.period] = (teamData[entry.cap][entry.period] || 0) + 1;
-    }
-
-    const periodHeaders = periodOrder.map((p) => Game.getPeriodLabel(p));
-    const colsPerTeam = 1 + periodHeaders.length + 1; // Cap + periods + Tot
-
-    for (const st of statTypes) {
-        const wCaps = Object.keys(counts[st.code].W).sort((a, b) => (parseInt(a) || 0) - (parseInt(b) || 0));
-        const dCaps = Object.keys(counts[st.code].D).sort((a, b) => (parseInt(a) || 0) - (parseInt(b) || 0));
-        if (wCaps.length === 0 && dCaps.length === 0) continue;
-
-        const tableEl = sheet._renderStatTypeTable(st, wCaps, dCaps, counts[st.code], periodOrder, periodHeaders, colsPerTeam);
-        const maxRows = Math.max(wCaps.length, dCaps.length);
-        // h3 title(1) + thead has 2 rows (team headers + column headers) + data rows
-        items.push({ el: tableEl, rows: 1 + 2 + maxRows });
-    }
-
-    if (items.length === 0) {
-        const empty = document.createElement("div");
-        empty.className = "sheet-section";
-        const p = document.createElement("p");
-        p.className = "sheet-empty";
-        p.textContent = "No stats recorded.";
-        empty.appendChild(p);
-        items.push({ el: empty, rows: 1 });
-    }
-
-    return items;
+        return { elements };
+    });
 }
 
-// ── Generic table pagination ─────────────────────────────────
+// ── Generic paginated rendering ──────────────────────────────
 
-export function paginateItems(items, availRows) {
-    const pages = [];
-    let currentElements = [];
-    let usedRows = 0;
+function _renderPaginatedPages(plan, descriptors, renderers) {
+    return plan.map((page) => {
+        const elements = [];
+        for (const item of page.items) {
+            const desc = descriptors[item.index];
+            const renderer = renderers[desc.type];
+            if (!renderer) continue;
 
-    const flushPage = () => {
-        if (currentElements.length > 0) {
-            pages.push({ elements: currentElements });
-            currentElements = [];
-            usedRows = 0;
+            if (!item.continued && item.startRow === 0 && item.endRow === desc.dataRows) {
+                // Full item — render normally
+                elements.push(renderer(desc.data));
+            } else {
+                // Split item — render full, then slice
+                elements.push(_renderSlice(renderer(desc.data), item, desc));
+            }
         }
-    };
+        return { elements };
+    });
+}
 
-    for (const item of items) {
-        const section = item.el;
-        const table = section.querySelector("table");
+function _renderSlice(fullEl, item, desc) {
+    const table = fullEl.querySelector("table");
+    if (!table) return fullEl;
 
-        // 1-row spacing between items on the same page
-        const spacing = currentElements.length > 0 ? 1 : 0;
+    const tbody = table.querySelector("tbody");
+    if (!tbody) return fullEl;
 
-        if (!table) {
-            // Non-table item (empty message etc.)
-            if (usedRows + spacing + item.rows > availRows) flushPage();
-            else usedRows += spacing;
-            currentElements.push(section);
-            usedRows += item.rows;
-            continue;
+    const allRows = Array.from(tbody.children);
+
+    const section = document.createElement("div");
+    section.className = fullEl.className;
+
+    // Title with optional " - continued" suffix
+    const titleEl = fullEl.querySelector(".sheet-section-title, h3");
+    if (titleEl) {
+        const titleClone = titleEl.cloneNode(true);
+        if (item.continued) {
+            titleClone.textContent = titleEl.textContent + " - continued";
         }
+        section.appendChild(titleClone);
+    }
 
-        const thead = table.querySelector("thead");
-        const tbody = table.querySelector("tbody");
-        if (!tbody) {
-            if (usedRows + spacing + item.rows > availRows) flushPage();
-            else usedRows += spacing;
-            currentElements.push(section);
-            usedRows += item.rows;
-            continue;
+    // Sliced table with repeated thead
+    const sliceTable = document.createElement("table");
+    sliceTable.className = table.className;
+    const thead = table.querySelector("thead");
+    if (thead) sliceTable.appendChild(thead.cloneNode(true));
+
+    const sliceTbody = document.createElement("tbody");
+    for (let i = item.startRow; i < item.endRow && i < allRows.length; i++) {
+        sliceTbody.appendChild(allRows[i].cloneNode(true));
+    }
+    sliceTable.appendChild(sliceTbody);
+    section.appendChild(sliceTable);
+
+    return section;
+}
+
+// ── Summary section renderers (data → DOM) ───────────────────
+
+function _renderPeriodScoresSection(data) {
+    const section = document.createElement("div");
+    section.className = "sheet-section";
+
+    const title = document.createElement("h3");
+    title.className = "sheet-section-title";
+    title.textContent = "Score by Period";
+    section.appendChild(title);
+
+    const table = document.createElement("table");
+    table.className = "sheet-table sheet-table-compact";
+
+    const headerCells = data.periods.map((p) => `<th>${p}</th>`).join("");
+    const thead = document.createElement("thead");
+    thead.innerHTML = `<tr><th>Team</th>${headerCells}<th>Total</th></tr>`;
+    table.appendChild(thead);
+
+    const tbody = document.createElement("tbody");
+    for (const [label, scores, total] of [["White", data.white, data.totalWhite], ["Dark", data.dark, data.totalDark]]) {
+        const tr = document.createElement("tr");
+        let cells = `<td class="sheet-team-cell">${label}</td>`;
+        for (const count of scores) {
+            cells += `<td>${String(count)}</td>`;
         }
+        cells += `<td class="sheet-total"><strong>${total}</strong></td>`;
+        tr.innerHTML = cells;
+        tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    section.appendChild(table);
+    return section;
+}
 
-        // Count title element (h3 or div.sheet-section-title) above the table
-        const titleEl = section.querySelector(".sheet-section-title, h3");
-        const titleRows = titleEl ? 1 : 0;
-        const theadRowCount = thead ? thead.querySelectorAll("tr").length : 0;
-        const allRows = Array.from(tbody.children);
+function _renderFoulSection(data) {
+    const section = document.createElement("div");
+    section.className = "sheet-section";
 
-        // Total for this item including spacing
-        const totalItemRows = spacing + titleRows + theadRowCount + allRows.length;
+    const title = document.createElement("h3");
+    title.className = "sheet-section-title";
+    title.textContent = "Personal Fouls";
+    section.appendChild(title);
 
-        // Does it fit entirely on current page?
-        if (usedRows + totalItemRows <= availRows) {
-            usedRows += spacing;
-            currentElements.push(section);
-            usedRows += titleRows + theadRowCount + allRows.length;
-            continue;
-        }
+    if (data.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "sheet-empty";
+        empty.textContent = "No personal fouls recorded.";
+        section.appendChild(empty);
+        return section;
+    }
 
-        // Anti-orphan: need at least title + thead + 1 data row to start
-        const minToStart = spacing + titleRows + theadRowCount + 1;
-        if (availRows - usedRows < minToStart) {
-            flushPage();
+    const table = document.createElement("table");
+    table.className = "sheet-table";
+    table.innerHTML = `<thead><tr><th>Team</th><th>Cap</th><th>Fouls</th><th>Details</th></tr></thead>`;
+
+    const tbody = document.createElement("tbody");
+    for (const player of data) {
+        const tr = document.createElement("tr");
+        if (player.fouledOut) tr.classList.add("sheet-fouled-out");
+        const details = player.details
+            .map((f) => `${Game.getPeriodLabel(f.period)} ${f.time} ${f.event}`)
+            .join("; ");
+        tr.innerHTML = `
+            <td>${player.team === "W" ? "White" : "Dark"}</td>
+            <td>${escapeHTML(player.cap)}</td>
+            <td>${player.count}</td>
+            <td class="sheet-foul-details">${escapeHTML(details)}</td>
+        `;
+        tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    section.appendChild(table);
+    return section;
+}
+
+function _renderTimeoutSection(data) {
+    const section = document.createElement("div");
+    section.className = "sheet-section";
+
+    const title = document.createElement("h3");
+    title.className = "sheet-section-title";
+    title.textContent = "Timeouts";
+    section.appendChild(title);
+
+    if (data.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "sheet-empty";
+        empty.textContent = "No timeouts recorded.";
+        section.appendChild(empty);
+        return section;
+    }
+
+    const table = document.createElement("table");
+    table.className = "sheet-table";
+    table.innerHTML = `<thead><tr><th>Team</th><th>Period</th><th>Time</th><th>Type</th></tr></thead>`;
+
+    const tbody = document.createElement("tbody");
+    for (const entry of data) {
+        const tr = document.createElement("tr");
+        tr.innerHTML = `
+            <td>${entry.team}</td>
+            <td>${entry.period}</td>
+            <td>${entry.time}</td>
+            <td>${entry.type}</td>
+        `;
+        tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    section.appendChild(table);
+    return section;
+}
+
+function _renderCardSection(data) {
+    const section = document.createElement("div");
+    section.className = "sheet-section";
+    section.innerHTML = `<div class="sheet-section-title">Cards</div>`;
+
+    if (data.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "sheet-empty";
+        empty.textContent = "No cards issued.";
+        section.appendChild(empty);
+        return section;
+    }
+
+    const table = document.createElement("table");
+    table.className = "sheet-table";
+    table.innerHTML = `<thead><tr><th>Team</th><th>Cap</th><th>Period</th><th>Time</th><th>Type</th></tr></thead>`;
+
+    const tbody = document.createElement("tbody");
+    for (const entry of data) {
+        const tr = document.createElement("tr");
+        tr.innerHTML = `
+            <td>${entry.team}</td>
+            <td>${escapeHTML(entry.cap)}</td>
+            <td>${entry.period}</td>
+            <td>${escapeHTML(entry.time)}</td>
+            <td>${entry.type}</td>
+        `;
+        tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    section.appendChild(table);
+    return section;
+}
+
+// ── Stats section renderer ───────────────────────────────────
+
+function _renderStatTypeFromDescriptor(desc, item) {
+    const statsData = desc.statsData;
+    const st = { code: desc.code, name: desc.name };
+
+    const wCaps = Object.keys(statsData.stats[st.code].W).sort((a, b) => (parseInt(a) || 0) - (parseInt(b) || 0));
+    const dCaps = Object.keys(statsData.stats[st.code].D).sort((a, b) => (parseInt(a) || 0) - (parseInt(b) || 0));
+    const colsPerTeam = 1 + statsData.periodLabels.length + 1; // Cap + periods + Tot
+    const periodHeaders = statsData.periodLabels;
+    const periodOrder = statsData.periods;
+
+    // Build full table
+    const wrapper = document.createElement("div");
+    wrapper.className = "sheet-section";
+
+    const title = document.createElement("h3");
+    title.className = "sheet-section-title";
+    title.textContent = item.continued ? st.name + " - continued" : st.name;
+    wrapper.appendChild(title);
+
+    const table = document.createElement("table");
+    table.className = "sheet-table sheet-table-compact sheet-table-stats";
+
+    const thead = document.createElement("thead");
+    const periodCols = periodHeaders.map((h) => `<th>${h}</th>`).join("");
+    thead.innerHTML = `
+        <tr>
+            <th colspan="${colsPerTeam}" class="sheet-team-header">White</th>
+            <th colspan="${colsPerTeam}" class="sheet-team-header">Dark</th>
+        </tr>
+        <tr>
+            <th>Cap</th>${periodCols}<th>Tot</th>
+            <th>Cap</th>${periodCols}<th>Tot</th>
+        </tr>
+    `;
+    table.appendChild(thead);
+
+    // Slice data rows based on item.startRow / item.endRow
+    const maxRows = Math.max(wCaps.length, dCaps.length);
+    const startRow = item.startRow;
+    const endRow = Math.min(item.endRow, maxRows);
+
+    const tbody = document.createElement("tbody");
+    for (let i = startRow; i < endRow; i++) {
+        const tr = document.createElement("tr");
+        let cells = "";
+
+        // White half
+        if (i < wCaps.length) {
+            const cap = wCaps[i];
+            const capData = statsData.stats[st.code].W[cap];
+            let total = 0;
+            cells += `<td>${escapeHTML(cap)}</td>`;
+            for (const period of periodOrder) {
+                const val = capData[period] || 0;
+                total += val;
+                cells += `<td>${val || ""}</td>`;
+            }
+            cells += `<td><strong>${total}</strong></td>`;
         } else {
-            usedRows += spacing;
+            cells += `<td></td>`.repeat(colsPerTeam);
         }
 
-        // Split table across pages
-        let rowIdx = 0;
-        let isFirstChunk = true;
-        while (rowIdx < allRows.length) {
-            const space = availRows - usedRows;
-            // Always count title row — first chunk gets original, continuations get "- continued"
-            const overhead = theadRowCount + titleRows;
-
-            // Anti-orphan: need overhead + at least 1 data row
-            if (space < overhead + 1) {
-                flushPage();
-                continue;
+        // Dark half
+        if (i < dCaps.length) {
+            const cap = dCaps[i];
+            const capData = statsData.stats[st.code].D[cap];
+            let total = 0;
+            cells += `<td>${escapeHTML(cap)}</td>`;
+            for (const period of periodOrder) {
+                const val = capData[period] || 0;
+                total += val;
+                cells += `<td>${val || ""}</td>`;
             }
-
-            const dataFit = space - overhead;
-            const end = Math.min(rowIdx + dataFit, allRows.length);
-
-            const chunkSection = document.createElement("div");
-            chunkSection.className = section.className;
-            if (titleEl) {
-                const titleClone = titleEl.cloneNode(true);
-                if (!isFirstChunk) {
-                    titleClone.textContent = titleEl.textContent + " - continued";
-                }
-                chunkSection.appendChild(titleClone);
-            }
-            const chunkTable = document.createElement("table");
-            chunkTable.className = table.className;
-            if (thead) chunkTable.appendChild(thead.cloneNode(true));
-            const chunkTbody = document.createElement("tbody");
-            for (let i = rowIdx; i < end; i++) {
-                chunkTbody.appendChild(allRows[i].cloneNode(true));
-            }
-            chunkTable.appendChild(chunkTbody);
-            chunkSection.appendChild(chunkTable);
-
-            currentElements.push(chunkSection);
-            usedRows += overhead + (end - rowIdx);
-            rowIdx = end;
-            isFirstChunk = false;
-
-            if (rowIdx < allRows.length) {
-                flushPage();
-            }
+            cells += `<td><strong>${total}</strong></td>`;
+        } else {
+            cells += `<td></td>`.repeat(colsPerTeam);
         }
-    }
 
-    if (currentElements.length > 0) {
-        pages.push({ elements: currentElements });
+        tr.innerHTML = cells;
+        tbody.appendChild(tr);
     }
-    if (pages.length === 0) pages.push({ elements: [] });
-    return pages;
+    table.appendChild(tbody);
+    wrapper.appendChild(table);
+    return wrapper;
 }

--- a/js/sheet-screen.js
+++ b/js/sheet-screen.js
@@ -17,24 +17,24 @@
 // wplog — Game Sheet Screen Rendering
 // Simple 2-page DOM layout for on-screen viewing.
 
-export function renderScreen(sheet, container) {
+export function renderScreen(game, sheet, container) {
     // Page 1: Header + Progress of Game
     const page1 = document.createElement("div");
     page1.className = "sheet-page";
-    page1.appendChild(sheet._renderHeader("Game Sheet"));
-    page1.appendChild(sheet._renderProgressOfGame());
+    page1.appendChild(sheet._renderHeader(game, "Game Sheet"));
+    page1.appendChild(sheet._renderProgressOfGame(game));
     container.appendChild(page1);
 
     // Page 2: Header (repeated) + Period Scores + Fouls + Timeouts + Cards + Player Stats
     const page2 = document.createElement("div");
     page2.className = "sheet-page sheet-page-break";
-    page2.appendChild(sheet._renderHeader("Game Sheet"));
-    page2.appendChild(sheet._renderPeriodScores());
-    page2.appendChild(sheet._renderFoulSummary());
-    page2.appendChild(sheet._renderTimeoutSummary());
-    page2.appendChild(sheet._renderCardSummary());
-    if (sheet.game.enableStats) {
-        page2.appendChild(sheet._renderPlayerStats());
+    page2.appendChild(sheet._renderHeader(game, "Game Sheet"));
+    page2.appendChild(sheet._renderPeriodScores(game));
+    page2.appendChild(sheet._renderFoulSummary(game));
+    page2.appendChild(sheet._renderTimeoutSummary(game));
+    page2.appendChild(sheet._renderCardSummary(game));
+    if (game.enableStats) {
+        page2.appendChild(sheet._renderPlayerStats(game));
     }
     container.appendChild(page2);
 }

--- a/js/sheet.js
+++ b/js/sheet.js
@@ -19,53 +19,57 @@ import { Game } from './game.js';
 import { escapeHTML } from './sanitize.js';
 import { buildPeriodScores, buildPersonalFoulTable, buildTimeoutSummary, buildCardSummary, buildPlayerStats } from './sheet-data.js';
 import { renderScreen } from './sheet-screen.js';
-import { buildLogPages, buildSummaryItems, buildStatsItems, paginateItems } from './sheet-print.js';
+import {
+    availableRows,
+    filterLogEvents,
+    buildLogPagePlan,
+    buildSummaryDescriptors,
+    buildStatsDescriptors,
+    paginateItems,
+} from './pagination.js';
+import { renderLogPages, renderSummaryPages, renderStatsPages } from './sheet-print.js';
 
-// wplog — Game Sheet (Orchestrator + Shared Helpers)
+// wplog — Game Sheet (Stateless Orchestrator + Shared Render Helpers)
+//
+// Sheet does not hold game state. All methods receive `game` as a parameter.
+// Pure pagination logic lives in pagination.js; DOM rendering in sheet-print.js.
 
 export const Sheet = {
-    game: null,
 
-    // Row-based print constants (all measurements in 18px rows).
-    _ROW_HEIGHT: 18,
-    // Measured header: title(26) + meta(94) + teams(40) + gaps(32) = 192px
-    // 192/18 = 10.67 → round up to 11.
-    _PAGE_ROWS: { letter: 52, a4: 56 },
-    _HEADER_ROWS: 12,
+    // ── Main entry point ─────────────────────────────────────────
 
-    init(game, paperSize) {
-        this.game = game;
-        this.render(paperSize || null);
-    },
-
-    // ── Main render ──────────────────────────────────────────────
-
-    render(paperSize) {
+    render(game, paperSize) {
         const container = document.getElementById("sheet-content");
         container.innerHTML = "";
 
-        const rules = RULES[this.game.rules];
         const isPrint = !!paperSize;
 
         if (!isPrint) {
-            renderScreen(this, container);
+            renderScreen(game, this, container);
             return;
         }
 
         // Print mode: paginated, multi-column log, sections on own pages
-        const availRows = this._PAGE_ROWS[paperSize] - this._HEADER_ROWS;
+        const avail = availableRows(paperSize);
+        const rules = RULES[game.rules];
 
         // === Section 1: Game Log ===
-        const logPages = buildLogPages(this, availRows);
+        const filteredLog = filterLogEvents(game.log, rules);
+        const logPlan = buildLogPagePlan(filteredLog.length, avail);
+        const logPages = renderLogPages(logPlan, filteredLog, game, rules, avail);
+
         // === Section 2: Game Summary ===
-        const summaryItems = buildSummaryItems(this);
-        const summaryPages = paginateItems(summaryItems, availRows);
+        const summaryDescriptors = buildSummaryDescriptors(game);
+        const summaryPlan = paginateItems(summaryDescriptors, avail);
+        const summaryPages = renderSummaryPages(summaryPlan, summaryDescriptors, game);
+
         // === Section 3: Game Stats (optional) ===
         let statsPages = [];
-        if (this.game.enableStats) {
-            const statsItems = buildStatsItems(this);
-            if (statsItems.length > 0) {
-                statsPages = paginateItems(statsItems, availRows);
+        if (game.enableStats) {
+            const statsDescriptors = buildStatsDescriptors(game);
+            if (statsDescriptors.length > 0) {
+                const statsPlan = paginateItems(statsDescriptors, avail);
+                statsPages = renderStatsPages(statsPlan, statsDescriptors, game);
             }
         }
 
@@ -88,7 +92,7 @@ export const Sheet = {
                 pageNum++;
                 const pageDiv = document.createElement("div");
                 pageDiv.className = "sheet-page" + (pageNum > 1 ? " sheet-page-break" : "");
-                pageDiv.appendChild(this._renderHeader(section.title, pageNum, totalPages));
+                pageDiv.appendChild(this._renderHeader(game, section.title, pageNum, totalPages));
                 for (const el of page.elements) {
                     pageDiv.appendChild(el);
                 }
@@ -99,8 +103,7 @@ export const Sheet = {
 
     // ── Header ───────────────────────────────────────────────────
 
-    _renderHeader(title, pageNum, totalPages) {
-        const game = this.game;
+    _renderHeader(game, title, pageNum, totalPages) {
         const header = document.createElement("div");
         header.className = "sheet-header";
 
@@ -147,7 +150,7 @@ export const Sheet = {
 
     // ── Existing render helpers (used by both screen + print) ────
 
-    _renderProgressOfGame() {
+    _renderProgressOfGame(game) {
         const section = document.createElement("div");
         section.className = "sheet-section";
 
@@ -172,13 +175,9 @@ export const Sheet = {
         table.appendChild(thead);
 
         const tbody = document.createElement("tbody");
-        const rules = RULES[this.game.rules];
+        const rules = RULES[game.rules];
 
-        const logEntries = this.game.log.filter((entry) => {
-            if (entry.event === "---") return true;
-            const eventDef = rules.events.find((e) => e.code === entry.event);
-            return !eventDef || !eventDef.statsOnly;
-        });
+        const logEntries = filterLogEvents(game.log, rules);
 
         for (const entry of logEntries) {
             const tr = document.createElement("tr");
@@ -194,7 +193,7 @@ export const Sheet = {
           <td>${escapeHTML(entry.cap || "—")}</td>
           <td>${escapeHTML(entry.team || "—")}</td>
           <td style="text-align:${align}">${escapeHTML(entry.event)}</td>
-          <td>${escapeHTML(Game.formatEntryScore(entry, this.game))}</td>
+          <td>${escapeHTML(Game.formatEntryScore(entry, game))}</td>
         `;
             }
             tbody.appendChild(tr);
@@ -205,8 +204,8 @@ export const Sheet = {
         return section;
     },
 
-    _renderPeriodScores() {
-        const data = buildPeriodScores(this.game);
+    _renderPeriodScores(game) {
+        const data = buildPeriodScores(game);
         const section = document.createElement("div");
         section.className = "sheet-section";
 
@@ -242,8 +241,8 @@ export const Sheet = {
         return section;
     },
 
-    _renderFoulSummary() {
-        const data = buildPersonalFoulTable(this.game);
+    _renderFoulSummary(game) {
+        const data = buildPersonalFoulTable(game);
         const section = document.createElement("div");
         section.className = "sheet-section";
 
@@ -292,8 +291,8 @@ export const Sheet = {
         return section;
     },
 
-    _renderTimeoutSummary() {
-        const data = buildTimeoutSummary(this.game);
+    _renderTimeoutSummary(game) {
+        const data = buildTimeoutSummary(game);
         const section = document.createElement("div");
         section.className = "sheet-section";
 
@@ -335,8 +334,8 @@ export const Sheet = {
         return section;
     },
 
-    _renderCardSummary() {
-        const data = buildCardSummary(this.game);
+    _renderCardSummary(game) {
+        const data = buildCardSummary(game);
         const section = document.createElement("div");
         section.className = "sheet-section";
         section.innerHTML = `<div class="sheet-section-title">Cards</div>`;
@@ -375,8 +374,8 @@ export const Sheet = {
         return section;
     },
 
-    _renderPlayerStats() {
-        const data = buildPlayerStats(this.game);
+    _renderPlayerStats(game) {
+        const data = buildPlayerStats(game);
         const section = document.createElement("div");
         section.className = "sheet-section";
 

--- a/sw.js
+++ b/sw.js
@@ -38,6 +38,7 @@ const ASSETS = [
     "./js/sheet-data.js",
     "./js/sheet-screen.js",
     "./js/sheet-print.js",
+    "./js/pagination.js",
     "./js/share.js",
     "./js/app.js",
     "./js/export.js",

--- a/tests/browser/smoke.test.js
+++ b/tests/browser/smoke.test.js
@@ -42,9 +42,6 @@ describe("Harness", () => {
         strictEqual(value, 42);
     });
 
-    it("todo tests are skipped", { todo: "harness demo" }, () => {
-        throw new Error("this should not run");
-    });
 });
 
 // ── DOM Access ───────────────────────────────────────────────

--- a/tests/pagination.test.js
+++ b/tests/pagination.test.js
@@ -1,0 +1,889 @@
+// Copyright 2026 Marko Milivojevic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it } from "node:test";
+import { strictEqual, deepStrictEqual, ok } from "node:assert";
+import { readFileSync } from "node:fs";
+import { Game } from "../js/game.js";
+import { RULES } from "../js/config.js";
+import {
+    PAGE_ROWS,
+    HEADER_ROWS,
+    ROW_HEIGHT,
+    availableRows,
+    filterLogEvents,
+    buildLogPagePlan,
+    buildSummaryDescriptors,
+    buildStatsDescriptors,
+    paginateItems,
+} from "../js/pagination.js";
+
+function loadTestData(name) {
+    return JSON.parse(readFileSync(`testdata/${name}`, "utf8"));
+}
+
+// ── Constants ────────────────────────────────────────────────
+
+describe("pagination constants", () => {
+    it("PAGE_ROWS has letter and a4", () => {
+        strictEqual(PAGE_ROWS.letter, 52);
+        strictEqual(PAGE_ROWS.a4, 56);
+    });
+
+    it("HEADER_ROWS is 12", () => {
+        strictEqual(HEADER_ROWS, 12);
+    });
+
+    it("ROW_HEIGHT is 18", () => {
+        strictEqual(ROW_HEIGHT, 18);
+    });
+});
+
+// ── availableRows ────────────────────────────────────────────
+
+describe("availableRows", () => {
+    it("letter = 52 - 12 = 40", () => {
+        strictEqual(availableRows("letter"), 40);
+    });
+
+    it("a4 = 56 - 12 = 44", () => {
+        strictEqual(availableRows("a4"), 44);
+    });
+});
+
+// ── filterLogEvents ──────────────────────────────────────────
+
+describe("filterLogEvents", () => {
+    it("returns empty array for empty log", () => {
+        const rules = RULES.USAWP;
+        deepStrictEqual(filterLogEvents([], rules), []);
+    });
+
+    it("keeps regular events", () => {
+        const rules = RULES.USAWP;
+        const log = [
+            { event: "G", period: 1, time: "7:00", team: "W", cap: "7" },
+            { event: "E", period: 1, time: "6:00", team: "D", cap: "3" },
+        ];
+        strictEqual(filterLogEvents(log, rules).length, 2);
+    });
+
+    it("keeps period-end markers", () => {
+        const rules = RULES.USAWP;
+        const log = [
+            { event: "G", period: 1, time: "7:00", team: "W", cap: "7" },
+            { event: "---", period: 1 },
+        ];
+        const result = filterLogEvents(log, rules);
+        strictEqual(result.length, 2);
+        strictEqual(result[1].event, "---");
+    });
+
+    it("filters out statsOnly events", () => {
+        const rules = RULES.USAWP;
+        const log = [
+            { event: "G", period: 1, time: "7:00", team: "W", cap: "7" },
+            { event: "Shot", period: 1, time: "6:00", team: "W", cap: "7" },
+            { event: "Assist", period: 1, time: "5:00", team: "W", cap: "9" },
+        ];
+        const result = filterLogEvents(log, rules);
+        strictEqual(result.length, 1);
+        strictEqual(result[0].event, "G");
+    });
+
+    it("preserves order", () => {
+        const rules = RULES.USAWP;
+        const log = [
+            { event: "E", period: 1, time: "7:00", team: "W", cap: "7" },
+            { event: "Shot", period: 1, time: "6:30", team: "W", cap: "7" },
+            { event: "G", period: 1, time: "6:00", team: "D", cap: "3" },
+            { event: "---", period: 1 },
+            { event: "P", period: 2, time: "7:00", team: "W", cap: "5" },
+        ];
+        const result = filterLogEvents(log, rules);
+        strictEqual(result.length, 4);
+        strictEqual(result[0].event, "E");
+        strictEqual(result[1].event, "G");
+        strictEqual(result[2].event, "---");
+        strictEqual(result[3].event, "P");
+    });
+
+    it("works with NFHS rules", () => {
+        const rules = RULES.NFHSVA;
+        const log = [
+            { event: "G", period: 1, time: "7:00", team: "W", cap: "7" },
+            { event: "MAM", period: 1, time: "6:00", team: "D", cap: "3" },
+            { event: "Shot", period: 1, time: "5:00", team: "W", cap: "7" },
+        ];
+        const result = filterLogEvents(log, rules);
+        strictEqual(result.length, 2); // G + MAM, Shot filtered
+        strictEqual(result[0].event, "G");
+        strictEqual(result[1].event, "MAM");
+    });
+});
+
+// ── buildLogPagePlan ─────────────────────────────────────────
+
+describe("buildLogPagePlan", () => {
+    it("returns empty array for 0 events", () => {
+        deepStrictEqual(buildLogPagePlan(0, 40), []);
+    });
+
+    it("returns empty array when availRows <= 1", () => {
+        deepStrictEqual(buildLogPagePlan(10, 1), []);
+        deepStrictEqual(buildLogPagePlan(10, 0), []);
+    });
+
+    it("single event → 1 page, 1 column", () => {
+        const plan = buildLogPagePlan(1, 40);
+        strictEqual(plan.length, 1);
+        strictEqual(plan[0].startIndex, 0);
+        strictEqual(plan[0].endIndex, 1);
+        strictEqual(plan[0].colCount, 1);
+    });
+
+    it("exactly rowsPerColumn events → 1 column", () => {
+        // availRows=40, rowsPerColumn=39 (minus 1 for thead)
+        const plan = buildLogPagePlan(39, 40);
+        strictEqual(plan.length, 1);
+        strictEqual(plan[0].colCount, 1);
+    });
+
+    it("rowsPerColumn + 1 events → 2 columns", () => {
+        const plan = buildLogPagePlan(40, 40);
+        strictEqual(plan.length, 1);
+        strictEqual(plan[0].colCount, 2);
+    });
+
+    it("2 * rowsPerColumn events → 2 columns", () => {
+        const plan = buildLogPagePlan(78, 40);
+        strictEqual(plan.length, 1);
+        strictEqual(plan[0].colCount, 2);
+    });
+
+    it("2 * rowsPerColumn + 1 events → 3 columns", () => {
+        const plan = buildLogPagePlan(79, 40);
+        strictEqual(plan.length, 1);
+        strictEqual(plan[0].colCount, 3);
+    });
+
+    it("max 3 columns per page", () => {
+        // 3 * 39 = 117 events = exactly 1 page of 3 columns
+        const plan = buildLogPagePlan(117, 40);
+        strictEqual(plan.length, 1);
+        strictEqual(plan[0].colCount, 3);
+    });
+
+    it("overflows to second page", () => {
+        // 118 events = 1 full page (117) + 1 on second page
+        const plan = buildLogPagePlan(118, 40);
+        strictEqual(plan.length, 2);
+        strictEqual(plan[0].startIndex, 0);
+        strictEqual(plan[0].endIndex, 117);
+        strictEqual(plan[0].colCount, 3);
+        strictEqual(plan[1].startIndex, 117);
+        strictEqual(plan[1].endIndex, 118);
+        strictEqual(plan[1].colCount, 1);
+    });
+
+    it("exact multi-page boundary", () => {
+        // 234 events = exactly 2 pages of 117 each
+        const plan = buildLogPagePlan(234, 40);
+        strictEqual(plan.length, 2);
+        strictEqual(plan[0].endIndex, 117);
+        strictEqual(plan[1].startIndex, 117);
+        strictEqual(plan[1].endIndex, 234);
+    });
+
+    it("start/end indices are contiguous", () => {
+        const plan = buildLogPagePlan(300, 40);
+        ok(plan.length > 1);
+        for (let i = 1; i < plan.length; i++) {
+            strictEqual(plan[i].startIndex, plan[i - 1].endIndex);
+        }
+        strictEqual(plan[plan.length - 1].endIndex, 300);
+    });
+});
+
+// ── buildSummaryDescriptors ──────────────────────────────────
+
+describe("buildSummaryDescriptors", () => {
+    it("returns 4 descriptors for new game", () => {
+        const g = Game.create("USAWP");
+        const desc = buildSummaryDescriptors(g);
+        strictEqual(desc.length, 4);
+        strictEqual(desc[0].type, "periodScores");
+        strictEqual(desc[1].type, "fouls");
+        strictEqual(desc[2].type, "timeouts");
+        strictEqual(desc[3].type, "cards");
+    });
+
+    it("periodScores always has 2 data rows", () => {
+        const g = Game.create("USAWP");
+        const desc = buildSummaryDescriptors(g);
+        strictEqual(desc[0].titleRows, 1);
+        strictEqual(desc[0].theadRows, 1);
+        strictEqual(desc[0].dataRows, 2);
+    });
+
+    it("empty fouls → theadRows=0, dataRows=1 (message)", () => {
+        const g = Game.create("USAWP");
+        const desc = buildSummaryDescriptors(g);
+        strictEqual(desc[1].theadRows, 0);
+        strictEqual(desc[1].dataRows, 1);
+    });
+
+    it("fouls with data → theadRows=1, dataRows=foul count", () => {
+        const g = Game.create("USAWP");
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", cap: "7", event: "E" });
+        Game.addEvent(g, { period: 1, time: "6:00", team: "D", cap: "3", event: "E" });
+        const desc = buildSummaryDescriptors(g);
+        strictEqual(desc[1].theadRows, 1);
+        strictEqual(desc[1].dataRows, 2);
+    });
+
+    it("timeouts with data → correct row count", () => {
+        const g = Game.create("USAWP");
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", event: "TO" });
+        Game.addEvent(g, { period: 2, time: "5:00", team: "D", event: "TO30" });
+        Game.addEvent(g, { period: 3, time: "4:00", team: "W", event: "TO" });
+        const desc = buildSummaryDescriptors(g);
+        strictEqual(desc[2].type, "timeouts");
+        strictEqual(desc[2].theadRows, 1);
+        strictEqual(desc[2].dataRows, 3);
+    });
+
+    it("cards with data → correct row count", () => {
+        const g = Game.create("USAWP");
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", cap: "C", event: "YC" });
+        const desc = buildSummaryDescriptors(g);
+        strictEqual(desc[3].type, "cards");
+        strictEqual(desc[3].theadRows, 1);
+        strictEqual(desc[3].dataRows, 1);
+    });
+
+    it("includes data objects for rendering", () => {
+        const g = Game.create("USAWP");
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", cap: "7", event: "G" });
+        const desc = buildSummaryDescriptors(g);
+        ok(desc[0].data); // periodScores data
+        ok(desc[0].data.periods);
+    });
+});
+
+// ── buildStatsDescriptors ────────────────────────────────────
+
+describe("buildStatsDescriptors", () => {
+    it("returns empty array when no stats events", () => {
+        const g = Game.create("USAWP");
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", cap: "7", event: "G" });
+        const desc = buildStatsDescriptors(g);
+        // Goals are not statsOnly, but buildPlayerStats returns them if cap+team exists
+        // However, if no stats at all, it might still return descriptors for goals
+        // The point is it doesn't crash
+        ok(Array.isArray(desc));
+    });
+
+    it("returns descriptors for stats events", () => {
+        const g = Game.create("USAWP");
+        g.enableStats = true;
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", cap: "7", event: "Shot" });
+        Game.addEvent(g, { period: 1, time: "6:00", team: "D", cap: "3", event: "Shot" });
+        const desc = buildStatsDescriptors(g);
+        ok(desc.length > 0);
+        const shotDesc = desc.find((d) => d.code === "Shot");
+        ok(shotDesc);
+        strictEqual(shotDesc.titleRows, 1);
+        strictEqual(shotDesc.theadRows, 2); // team header + column header
+    });
+
+    it("dataRows = max(wCaps, dCaps)", () => {
+        const g = Game.create("USAWP");
+        g.enableStats = true;
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", cap: "7", event: "Shot" });
+        Game.addEvent(g, { period: 1, time: "6:00", team: "W", cap: "9", event: "Shot" });
+        Game.addEvent(g, { period: 1, time: "5:00", team: "D", cap: "3", event: "Shot" });
+        const desc = buildStatsDescriptors(g);
+        const shotDesc = desc.find((d) => d.code === "Shot");
+        strictEqual(shotDesc.dataRows, 2); // 2 white caps, 1 dark cap → max=2
+    });
+
+    it("skips stat types with no entries", () => {
+        const g = Game.create("USAWP");
+        g.enableStats = true;
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", cap: "7", event: "Shot" });
+        // Only Shot, no Assist/Steal/etc.
+        const desc = buildStatsDescriptors(g);
+        const assistDesc = desc.find((d) => d.code === "Assist");
+        strictEqual(assistDesc, undefined);
+    });
+});
+
+// ── paginateItems ────────────────────────────────────────────
+
+describe("paginateItems", () => {
+    it("returns single empty page for no descriptors", () => {
+        const result = paginateItems([], 40);
+        strictEqual(result.length, 1);
+        strictEqual(result[0].items.length, 0);
+    });
+
+    it("single small item fits on one page", () => {
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 3 },
+        ], 40);
+        strictEqual(result.length, 1);
+        strictEqual(result[0].items.length, 1);
+        strictEqual(result[0].items[0].index, 0);
+        strictEqual(result[0].items[0].startRow, 0);
+        strictEqual(result[0].items[0].endRow, 3);
+        strictEqual(result[0].items[0].continued, false);
+    });
+
+    it("multiple small items fit on one page", () => {
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 3 }, // 5 rows
+            { titleRows: 1, theadRows: 1, dataRows: 2 }, // 4 rows + 1 spacing = 5
+            { titleRows: 1, theadRows: 1, dataRows: 1 }, // 3 rows + 1 spacing = 4
+        ], 40); // total = 5 + 5 + 4 = 14, fits in 40
+        strictEqual(result.length, 1);
+        strictEqual(result[0].items.length, 3);
+    });
+
+    it("items overflow to next page", () => {
+        // First item fills 38 rows, leaving 2. Second needs spacing(1)+title(1)+thead(1)+1=4 min.
+        // Can't start → pushed to next page entirely.
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 36 }, // 38 rows
+            { titleRows: 1, theadRows: 1, dataRows: 5 },  // needs 3 min start, only 2-1=1 left
+        ], 40);
+        strictEqual(result.length, 2);
+        strictEqual(result[0].items.length, 1);
+        strictEqual(result[1].items.length, 1);
+        strictEqual(result[1].items[0].index, 1);
+        strictEqual(result[1].items[0].continued, false);
+    });
+
+    it("non-table item (theadRows=0) still paginates", () => {
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 0, dataRows: 1 }, // empty message
+        ], 40);
+        strictEqual(result.length, 1);
+        strictEqual(result[0].items[0].endRow, 1);
+    });
+
+    it("splits large table across pages", () => {
+        // Item needs 1+1+50=52 rows, but only 40 available
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 50 },
+        ], 40);
+        ok(result.length >= 2);
+        // First chunk
+        strictEqual(result[0].items[0].startRow, 0);
+        strictEqual(result[0].items[0].continued, false);
+        // Second chunk should have continued=true
+        strictEqual(result[1].items[0].continued, true);
+        strictEqual(result[1].items[0].index, 0);
+    });
+
+    it("continued chunks have correct startRow/endRow", () => {
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 100 },
+        ], 40);
+        // All data rows should be covered
+        let totalDataRows = 0;
+        for (const page of result) {
+            for (const item of page.items) {
+                totalDataRows += item.endRow - item.startRow;
+            }
+        }
+        strictEqual(totalDataRows, 100);
+    });
+
+    it("anti-orphan: flushes to next page if can't fit title+thead+1", () => {
+        // Fill page almost completely, then add a splittable table
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 36 }, // 38 rows, 2 remaining
+            { titleRows: 1, theadRows: 1, dataRows: 5 },  // needs title+thead+1=3 min, but only 2-1(spacing)=1 remaining
+        ], 40);
+        strictEqual(result.length, 2);
+        strictEqual(result[1].items[0].index, 1);
+        strictEqual(result[1].items[0].continued, false);
+    });
+
+    it("spacing between items on same page", () => {
+        // Two items that almost fill the page with spacing
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 18 }, // 20 rows
+            { titleRows: 1, theadRows: 1, dataRows: 18 }, // 20 rows + 1 spacing = 21
+        ], 41); // total = 41, exactly fits
+        strictEqual(result.length, 1);
+        strictEqual(result[0].items.length, 2);
+    });
+
+    it("exact fit on page boundary", () => {
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 38 }, // 40 rows = exactly fill the page
+        ], 40);
+        strictEqual(result.length, 1);
+        strictEqual(result[0].items[0].endRow, 38);
+    });
+
+    it("preserves descriptor indices across pages", () => {
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 38 }, // fills page 1
+            { titleRows: 1, theadRows: 1, dataRows: 38 }, // fills page 2
+            { titleRows: 1, theadRows: 1, dataRows: 5 },  // page 3
+        ], 40);
+        strictEqual(result.length, 3);
+        strictEqual(result[0].items[0].index, 0);
+        strictEqual(result[1].items[0].index, 1);
+        strictEqual(result[2].items[0].index, 2);
+    });
+
+    it("split table produces contiguous startRow/endRow ranges", () => {
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 200 },
+        ], 40);
+        let lastEnd = 0;
+        for (const page of result) {
+            for (const item of page.items) {
+                strictEqual(item.startRow, lastEnd);
+                ok(item.endRow > item.startRow);
+                lastEnd = item.endRow;
+            }
+        }
+        strictEqual(lastEnd, 200);
+    });
+});
+
+// ── filterLogEvents — additional rule sets ───────────────────
+
+describe("filterLogEvents — rule set coverage", () => {
+    it("works with NCAA rules", () => {
+        const rules = RULES.NCAA;
+        const log = [
+            { event: "G", period: 1, time: "7:00", team: "W", cap: "7" },
+            { event: "E", period: 1, time: "6:00", team: "D", cap: "3" },
+            { event: "YRC", period: 1, time: "5:00", team: "W", cap: "C" },
+            { event: "Shot", period: 1, time: "4:00", team: "W", cap: "7" },
+        ];
+        const result = filterLogEvents(log, rules);
+        strictEqual(result.length, 3); // G, E, YRC — Shot filtered
+    });
+
+    it("works with NFHS JV rules", () => {
+        const rules = RULES.NFHSJV;
+        const log = [
+            { event: "G", period: 1, time: "6:00", team: "W", cap: "7" },
+            { event: "TO", period: 1, time: "5:00", team: "D" },
+            { event: "Steal", period: 1, time: "4:00", team: "W", cap: "7" },
+        ];
+        const result = filterLogEvents(log, rules);
+        strictEqual(result.length, 2); // G + TO, Steal filtered
+    });
+
+    it("returns empty if log is all statsOnly events", () => {
+        const rules = RULES.USAWP;
+        const log = [
+            { event: "Shot", period: 1, time: "7:00", team: "W", cap: "7" },
+            { event: "Assist", period: 1, time: "6:00", team: "W", cap: "9" },
+            { event: "Steal", period: 1, time: "5:00", team: "D", cap: "3" },
+        ];
+        strictEqual(filterLogEvents(log, rules).length, 0);
+    });
+
+    it("keeps events with unknown codes (defensive)", () => {
+        const rules = RULES.USAWP;
+        const log = [
+            { event: "UNKNOWN", period: 1, time: "7:00", team: "W", cap: "7" },
+        ];
+        // Unknown event = no eventDef found = !eventDef = true = kept
+        strictEqual(filterLogEvents(log, rules).length, 1);
+    });
+});
+
+// ── buildLogPagePlan — A4 paper size ─────────────────────────
+
+describe("buildLogPagePlan — A4 paper", () => {
+    const a4Avail = 44; // availableRows("a4")
+
+    it("rowsPerColumn is 43 for A4", () => {
+        // 1 event → 1 col
+        const plan = buildLogPagePlan(43, a4Avail);
+        strictEqual(plan[0].colCount, 1);
+    });
+
+    it("44 events → 2 columns on A4", () => {
+        const plan = buildLogPagePlan(44, a4Avail);
+        strictEqual(plan[0].colCount, 2);
+    });
+
+    it("max 3*43=129 events per A4 page", () => {
+        const plan = buildLogPagePlan(129, a4Avail);
+        strictEqual(plan.length, 1);
+        strictEqual(plan[0].colCount, 3);
+    });
+
+    it("130 events → 2 pages on A4", () => {
+        const plan = buildLogPagePlan(130, a4Avail);
+        strictEqual(plan.length, 2);
+        strictEqual(plan[0].endIndex, 129);
+    });
+});
+
+// ── buildSummaryDescriptors — populated games ────────────────
+
+describe("buildSummaryDescriptors — populated games", () => {
+    it("all sections populated", () => {
+        const g = Game.create("USAWP");
+        // Goals
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", cap: "7", event: "G" });
+        Game.addEvent(g, { period: 1, time: "6:00", team: "D", cap: "3", event: "G" });
+        // Fouls
+        Game.addEvent(g, { period: 1, time: "5:00", team: "W", cap: "7", event: "E" });
+        Game.addEvent(g, { period: 2, time: "7:00", team: "D", cap: "3", event: "P" });
+        Game.addEvent(g, { period: 2, time: "6:00", team: "W", cap: "9", event: "E" });
+        // Timeouts
+        Game.addEvent(g, { period: 2, time: "5:00", team: "W", event: "TO" });
+        // Cards
+        Game.addEvent(g, { period: 3, time: "7:00", team: "W", cap: "C", event: "YC" });
+        Game.addEvent(g, { period: 3, time: "6:00", team: "D", cap: "AC", event: "RC" });
+
+        const desc = buildSummaryDescriptors(g);
+        strictEqual(desc.length, 4);
+
+        // All sections have real data
+        strictEqual(desc[0].theadRows, 1); // periodScores always has thead
+        strictEqual(desc[1].theadRows, 1); // fouls with data
+        strictEqual(desc[1].dataRows, 3);  // 3 players fouled
+        strictEqual(desc[2].theadRows, 1); // timeout with data
+        strictEqual(desc[2].dataRows, 1);  // 1 timeout
+        strictEqual(desc[3].theadRows, 1); // cards with data
+        strictEqual(desc[3].dataRows, 2);  // 2 cards
+    });
+
+    it("total rows match expectations for sum", () => {
+        const g = Game.create("USAWP");
+        const desc = buildSummaryDescriptors(g);
+        // Empty game: periodScores(1+1+2=4) + fouls(1+0+1=2) + timeouts(1+0+1=2) + cards(1+0+1=2) = 10
+        let totalRows = 0;
+        for (const d of desc) {
+            totalRows += d.titleRows + d.theadRows + d.dataRows;
+        }
+        strictEqual(totalRows, 10);
+    });
+
+    it("works with NFHS Varsity", () => {
+        const g = Game.create("NFHSVA");
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", cap: "7", event: "MAM" });
+        const desc = buildSummaryDescriptors(g);
+        strictEqual(desc[1].type, "fouls");
+        strictEqual(desc[1].dataRows, 1); // MAM is a personal foul
+    });
+
+    it("data objects match sheet-data builder outputs", () => {
+        const g = Game.create("USAWP");
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", cap: "7", event: "G" });
+        Game.addEvent(g, { period: 1, time: "6:00", team: "W", cap: "7", event: "E" });
+        const desc = buildSummaryDescriptors(g);
+        // periodScores data should have correct totals
+        strictEqual(desc[0].data.totalWhite, "1");
+        // fouls data should have correct details
+        ok(Array.isArray(desc[1].data));
+        strictEqual(desc[1].data.length, 1);
+        strictEqual(desc[1].data[0].cap, "7");
+    });
+});
+
+// ── buildStatsDescriptors — additional coverage ──────────────
+
+describe("buildStatsDescriptors — additional", () => {
+    it("multiple stat types produce multiple descriptors", () => {
+        const g = Game.create("USAWP");
+        g.enableStats = true;
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", cap: "7", event: "Shot" });
+        Game.addEvent(g, { period: 1, time: "6:00", team: "W", cap: "7", event: "Assist" });
+        Game.addEvent(g, { period: 1, time: "5:00", team: "D", cap: "3", event: "Steal" });
+        const desc = buildStatsDescriptors(g);
+        const codes = desc.map((d) => d.code);
+        ok(codes.includes("Shot"));
+        ok(codes.includes("Assist"));
+        ok(codes.includes("Steal"));
+    });
+
+    it("asymmetric teams: more dark caps than white", () => {
+        const g = Game.create("USAWP");
+        g.enableStats = true;
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", cap: "7", event: "Shot" });
+        Game.addEvent(g, { period: 1, time: "6:00", team: "D", cap: "3", event: "Shot" });
+        Game.addEvent(g, { period: 1, time: "5:00", team: "D", cap: "5", event: "Shot" });
+        Game.addEvent(g, { period: 1, time: "4:00", team: "D", cap: "9", event: "Shot" });
+        const desc = buildStatsDescriptors(g);
+        const shotDesc = desc.find((d) => d.code === "Shot");
+        strictEqual(shotDesc.dataRows, 3); // max(1 white, 3 dark) = 3
+    });
+
+    it("carries statsData on each descriptor", () => {
+        const g = Game.create("USAWP");
+        g.enableStats = true;
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", cap: "7", event: "Shot" });
+        const desc = buildStatsDescriptors(g);
+        ok(desc.length > 0);
+        ok(desc[0].statsData);
+        ok(desc[0].statsData.statTypes);
+        ok(desc[0].statsData.periodLabels);
+    });
+
+    it("returns empty for game with only team-level events", () => {
+        const g = Game.create("USAWP");
+        g.enableStats = true;
+        Game.addEvent(g, { period: 1, time: "7:00", team: "W", event: "TO" });
+        const desc = buildStatsDescriptors(g);
+        // TO is teamOnly — no cap → won't appear in player stats
+        // buildPlayerStats may return null
+        strictEqual(desc.length, 0);
+    });
+});
+
+// ── paginateItems — edge cases ───────────────────────────────
+
+describe("paginateItems — edge cases", () => {
+    it("multi-split: table spanning 3+ pages", () => {
+        // 200 data rows, overhead=2, avail=10 → 8 data rows per chunk → ceil(200/8)=25 pages
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 200 },
+        ], 10);
+        strictEqual(result.length, 25);
+        // First chunk is not continued
+        strictEqual(result[0].items[0].continued, false);
+        // All subsequent chunks are continued
+        for (let i = 1; i < result.length; i++) {
+            strictEqual(result[i].items[0].continued, true);
+        }
+    });
+
+    it("interleaved: small item then large split item", () => {
+        // Small item takes 5 rows (1+1+3), then big item needs 50
+        // avail=20: small fits on page 1, 15 left, big starts with overhead+1=3, 15>=3
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 3 },  // 5 rows
+            { titleRows: 1, theadRows: 1, dataRows: 50 }, // needs splitting
+        ], 20);
+        // Page 1: small item + start of big item
+        strictEqual(result[0].items.length, 2);
+        strictEqual(result[0].items[0].index, 0); // small
+        strictEqual(result[0].items[1].index, 1); // first chunk of big
+        strictEqual(result[0].items[1].continued, false);
+        // Remaining pages: continued chunks of big item
+        for (let i = 1; i < result.length; i++) {
+            strictEqual(result[i].items[0].index, 1);
+            strictEqual(result[i].items[0].continued, true);
+        }
+    });
+
+    it("all non-splittable items (theadRows=0)", () => {
+        const items = Array.from({ length: 5 }, () => ({
+            titleRows: 1, theadRows: 0, dataRows: 1, // 2 rows each
+        }));
+        const result = paginateItems(items, 10);
+        // 5 items: 2 + (1+2) + (1+2) + (1+2) + (1+2) = 2+3+3+3+3 = 14 rows, needs 2 pages
+        strictEqual(result.length, 2);
+    });
+
+    it("many tiny items fill multiple pages", () => {
+        // 20 items, each 3 rows (1+1+1), spacing adds 1 between
+        // First item: 3. Each subsequent: 4. Total = 3 + 19*4 = 79
+        const items = Array.from({ length: 20 }, () => ({
+            titleRows: 1, theadRows: 1, dataRows: 1,
+        }));
+        const result = paginateItems(items, 20);
+        // Should fit ~5 per page (3 + 4 + 4 + 4 + 4 = 19 ≤ 20, next would be 23 > 20)
+        let totalItems = 0;
+        for (const page of result) totalItems += page.items.length;
+        strictEqual(totalItems, 20);
+    });
+
+    it("minimal availRows: just enough for overhead + 1", () => {
+        // availRows=3, overhead=2 (title+thead), so exactly 1 data row fits per page
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 5 },
+        ], 3);
+        strictEqual(result.length, 5); // 1 data row per page
+        for (let i = 0; i < 5; i++) {
+            strictEqual(result[i].items[0].startRow, i);
+            strictEqual(result[i].items[0].endRow, i + 1);
+        }
+    });
+
+    it("mix of split and whole items", () => {
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 38 }, // exactly fills page 1
+            { titleRows: 1, theadRows: 0, dataRows: 1 },  // non-splittable, page 2
+            { titleRows: 1, theadRows: 1, dataRows: 50 }, // split starting page 2
+        ], 40);
+        strictEqual(result[0].items.length, 1);
+        strictEqual(result[0].items[0].index, 0);
+        // Page 2 starts with item 1 (non-splittable) then item 2 starts
+        ok(result[1].items.length >= 1);
+        strictEqual(result[1].items[0].index, 1); // non-splittable
+    });
+
+    it("item that exactly fills remaining space after spacing", () => {
+        // First item: 10 rows. Spacing: 1. Second item: 29 rows (1+1+27). Total: 10+1+29=40
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 8 },  // 10 rows
+            { titleRows: 1, theadRows: 1, dataRows: 27 }, // 29 rows + 1 spacing = 30
+        ], 40);
+        strictEqual(result.length, 1);
+        strictEqual(result[0].items.length, 2);
+    });
+
+    it("single row overflow triggers new page", () => {
+        // 10 + 1(spacing) + 30 = 41 > 40
+        const result = paginateItems([
+            { titleRows: 1, theadRows: 1, dataRows: 8 },  // 10 rows
+            { titleRows: 1, theadRows: 1, dataRows: 28 }, // 30 rows + 1 spacing = 31
+        ], 40);
+        // Second item starts on page 1 (can fit overhead+1=3), splits continuation
+        ok(result.length >= 1);
+        // Verify all data is covered
+        let dataSum = 0;
+        for (const page of result) {
+            for (const item of page.items) {
+                dataSum += item.endRow - item.startRow;
+            }
+        }
+        strictEqual(dataSum, 8 + 28);
+    });
+
+    it("no page exceeds availRows", () => {
+        const descriptors = [
+            { titleRows: 1, theadRows: 1, dataRows: 15 },
+            { titleRows: 1, theadRows: 1, dataRows: 30 },
+            { titleRows: 1, theadRows: 0, dataRows: 1 },
+            { titleRows: 1, theadRows: 1, dataRows: 8 },
+        ];
+        const avail = 25;
+        const result = paginateItems(descriptors, avail);
+        for (let p = 0; p < result.length; p++) {
+            let pageRows = 0;
+            for (let i = 0; i < result[p].items.length; i++) {
+                const item = result[p].items[i];
+                const desc = descriptors[item.index];
+                if (i > 0) pageRows += 1; // spacing
+                pageRows += desc.titleRows + desc.theadRows + (item.endRow - item.startRow);
+            }
+            ok(pageRows <= avail, `page ${p} uses ${pageRows} rows, max ${avail}`);
+        }
+    });
+});
+
+// ── Integration invariants ───────────────────────────────────
+
+describe("pagination invariants with test data", () => {
+    for (const file of ["small-game.json", "medium-game.json", "large-game.json"]) {
+        describe(file, () => {
+            const gameData = loadTestData(file);
+            const rules = RULES[gameData.rules];
+
+            for (const paperSize of ["letter", "a4"]) {
+                describe(`${paperSize} paper`, () => {
+                    const avail = availableRows(paperSize);
+
+                    it("log plan covers all events contiguously", () => {
+                        const filtered = filterLogEvents(gameData.log, rules);
+                        const plan = buildLogPagePlan(filtered.length, avail);
+                        if (plan.length === 0) return;
+                        strictEqual(plan[0].startIndex, 0);
+                        for (let i = 1; i < plan.length; i++) {
+                            strictEqual(plan[i].startIndex, plan[i - 1].endIndex);
+                        }
+                        strictEqual(plan[plan.length - 1].endIndex, filtered.length);
+                    });
+
+                    it("log plan column counts are 1-3", () => {
+                        const filtered = filterLogEvents(gameData.log, rules);
+                        const plan = buildLogPagePlan(filtered.length, avail);
+                        for (const page of plan) {
+                            ok(page.colCount >= 1 && page.colCount <= 3,
+                                `colCount ${page.colCount} out of range`);
+                        }
+                    });
+
+                    it("summary pagination covers all descriptor data", () => {
+                        const desc = buildSummaryDescriptors(gameData);
+                        const plan = paginateItems(desc, avail);
+                        // Every descriptor index must appear at least once
+                        const seenIndices = new Set();
+                        for (const page of plan) {
+                            for (const item of page.items) {
+                                seenIndices.add(item.index);
+                            }
+                        }
+                        for (let i = 0; i < desc.length; i++) {
+                            ok(seenIndices.has(i), `descriptor ${i} (${desc[i].type}) missing from plan`);
+                        }
+                    });
+
+                    it("summary pagination: data rows covered per descriptor", () => {
+                        const desc = buildSummaryDescriptors(gameData);
+                        const plan = paginateItems(desc, avail);
+                        // Sum data rows rendered for each descriptor
+                        const rowsPerDesc = new Map();
+                        for (const page of plan) {
+                            for (const item of page.items) {
+                                const prev = rowsPerDesc.get(item.index) || 0;
+                                rowsPerDesc.set(item.index, prev + (item.endRow - item.startRow));
+                            }
+                        }
+                        for (let i = 0; i < desc.length; i++) {
+                            strictEqual(rowsPerDesc.get(i), desc[i].dataRows,
+                                `descriptor ${i} (${desc[i].type}): expected ${desc[i].dataRows} data rows, got ${rowsPerDesc.get(i)}`);
+                        }
+                    });
+
+                    it("no summary page exceeds available rows", () => {
+                        const desc = buildSummaryDescriptors(gameData);
+                        const plan = paginateItems(desc, avail);
+                        for (let p = 0; p < plan.length; p++) {
+                            let pageRows = 0;
+                            for (let i = 0; i < plan[p].items.length; i++) {
+                                const item = plan[p].items[i];
+                                const d = desc[item.index];
+                                if (i > 0) pageRows += 1;
+                                pageRows += d.titleRows + d.theadRows + (item.endRow - item.startRow);
+                            }
+                            ok(pageRows <= avail, `${file} ${paperSize} summary page ${p}: ${pageRows} rows > ${avail}`);
+                        }
+                    });
+
+                    it("stats pagination covers all descriptors if present", () => {
+                        const desc = buildStatsDescriptors(gameData);
+                        if (desc.length === 0) return;
+                        const plan = paginateItems(desc, avail);
+                        const seenIndices = new Set();
+                        for (const page of plan) {
+                            for (const item of page.items) seenIndices.add(item.index);
+                        }
+                        for (let i = 0; i < desc.length; i++) {
+                            ok(seenIndices.has(i), `stats descriptor ${i} (${desc[i].code}) missing`);
+                        }
+                    });
+                });
+            }
+        });
+    }
+});
+


### PR DESCRIPTION
- New js/pagination.js: pure pagination math (filterLogEvents,
  buildLogPagePlan, buildSummaryDescriptors, buildStatsDescriptors,
  paginateItems, availableRows) — zero DOM dependency
- Stateless Sheet: removed Sheet.game and Sheet.init(), replaced with
  Sheet.render(game, paperSize), all render methods accept game param
- sheet-print.js: DOM-only rendering layer consuming pagination plans
- sheet-screen.js: updated to pass game to all render calls
- app.js, share.js: Sheet.init → Sheet.render at all call sites
- sw.js: added pagination.js to precache assets
- New tests/pagination.test.js: 106 tests covering all pure functions
- browser-testing skill: added window.print() gotcha
- AGENTS.md: updated architecture and What's Done
