### PR TITLE
refactor: extract time parsing from events.js into time.js

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ wplog/
 │   ├── game.js         # Core data model + game logic (pure — no Storage dependency)
 │   ├── setup.js        # Setup screen (with active-game guards)
 │   ├── events.js       # Live log screen (main UI, owns Storage.save after mutations)
+│   ├── time.js         # Time parsing utilities (pure — no DOM, no game state)
 │   ├── sheet.js        # Game sheet orchestrator + shared render helpers (stateless — no stored game)
 │   ├── sheet-data.js   # Sheet data builders (pure — no DOM)
 │   ├── sheet-screen.js # Game sheet screen rendering (2-page DOM layout)
@@ -321,6 +322,7 @@ Inherits from `_academic` (8-min periods). Adds:
 - Pagination engine extracted: `pagination.js` exports pure functions (`filterLogEvents`, `buildLogPagePlan`, `buildSummaryDescriptors`, `buildStatsDescriptors`, `paginateItems`, `availableRows`) — all print layout math with zero DOM dependency
 - Stateless Sheet: `Sheet.game` removed, `Sheet.init()` replaced with `Sheet.render(game, paperSize)` — all render methods accept `game` as parameter
 - `sheet-print.js` refactored to DOM-only rendering layer — consumes pagination plans from `pagination.js`, no pagination arithmetic
+- Time parsing extracted: `time.js` exports pure functions (`getMaxMinutes`, `parseTime`, `formatTimeDisplay`) — `events.js` delegates via thin wrappers
 
 ### Known Gaps / Future Work 📋
 - No substitution tracking (user hasn't decided)

--- a/js/events.js
+++ b/js/events.js
@@ -19,6 +19,7 @@ import { ConfirmDialog } from './confirm.js';
 import { Game } from './game.js';
 import { escapeHTML } from './sanitize.js';
 import { Storage } from './storage.js';
+import { getMaxMinutes, parseTime, formatTimeDisplay } from './time.js';
 
 // wplog — Live Log Screen (Event Logging)
 // Event-first workflow: tap event button → modal opens → enter details → OK
@@ -47,60 +48,21 @@ export const Events = {
     },
 
     // ── Time Parsing ────────────────────────────────────────
-    // Water polo game clock: M:SS format
-    // Digits fill right-to-left: S2, S1, M
-    // "4"   → 0:04  (4 seconds)
-    // "45"  → 0:45  (45 seconds)
-    // "453" → 4:53  (4 min 53 sec)
-    // Max time is capped by the current period's length.
+    // Delegated to pure functions in time.js:
+    //   getMaxMinutes(period, periodLength, otPeriodLength)
+    //   parseTime(digits, maxMinutes)
+    //   formatTimeDisplay(digits)
 
     _getMaxMinutes() {
-        const period = this.game.currentPeriod;
-        if (period === "SO") return 0;
-        if (typeof period === "string" && period.startsWith("OT")) {
-            return this.game.otPeriodLength || 3;
-        }
-        return this.game.periodLength || 8;
+        return getMaxMinutes(this.game.currentPeriod, this.game.periodLength, this.game.otPeriodLength);
     },
 
     _parseTime(digits) {
-        if (digits.length === 0) return null;
-
-        // Right-justify into 3 positions: M S1 S2
-        const padded = digits.padStart(3, "0");
-        const minutes = parseInt(padded[0]);
-        const seconds = parseInt(padded.slice(1));
-
-        if (seconds > 59 || minutes > 9) return null;
-
-        // Cap at period length
-        const maxMin = this._getMaxMinutes();
-        if (minutes > maxMin || (minutes === maxMin && seconds > 0)) return null;
-
-        return {
-            display: minutes + ":" + String(seconds).padStart(2, "0"),
-            stored: minutes + ":" + String(seconds).padStart(2, "0"),
-        };
+        return parseTime(digits, this._getMaxMinutes());
     },
 
     _formatTimeDisplay(digits) {
-        // Right-to-left fill into M:S1S2 — placeholder is -:--
-        const padded = digits.padStart(3, "\0"); // pad with nulls
-        const parts = [];
-
-        for (let i = 0; i < 3; i++) {
-            if (padded[i] === "\0") {
-                parts.push(`<span class="time-placeholder">-</span>`);
-            } else {
-                parts.push(padded[i]);
-            }
-        }
-
-        // Colon is dim only when no digits entered
-        const colonClass = digits.length > 0 ? "" : ' class="time-placeholder"';
-
-        // Minutes placeholder shows for 0-2 digits, hidden when 3 digits (minutes filled)
-        return `<span class="time-formatted">${parts[0]}<span${colonClass}>:</span>${parts[1]}${parts[2]}</span>`;
+        return formatTimeDisplay(digits);
     },
 
     // ── Modal Controls ──────────────────────────────────────

--- a/js/time.js
+++ b/js/time.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2026 Marko Milivojevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// wplog — Time Parsing Utilities (pure — no DOM, no game state)
+
+/**
+ * Returns the maximum minutes for a given period.
+ *
+ * @param {number|string} period - Current period (1-4, "OT1", "OT2", ..., "SO")
+ * @param {number} periodLength - Quarter length in minutes (default 8)
+ * @param {number|null} otPeriodLength - OT period length in minutes (default 3)
+ * @returns {number} Maximum minutes allowed
+ */
+export function getMaxMinutes(period, periodLength, otPeriodLength) {
+    if (period === "SO") return 0;
+    if (typeof period === "string" && period.startsWith("OT")) {
+        return otPeriodLength || 3;
+    }
+    return periodLength || 8;
+}
+
+/**
+ * Parses raw digit input into a game clock time.
+ *
+ * Water polo game clock: M:SS format.
+ * Digits fill right-to-left: S2, S1, M.
+ *   "4"   → 0:04  (4 seconds)
+ *   "45"  → 0:45  (45 seconds)
+ *   "453" → 4:53  (4 min 53 sec)
+ *
+ * @param {string} digits - Raw digit string (0-3 chars)
+ * @param {number} maxMinutes - Maximum minutes for the current period
+ * @returns {{ display: string, stored: string } | null} Parsed time or null if invalid
+ */
+export function parseTime(digits, maxMinutes) {
+    if (digits.length === 0) return null;
+
+    // Right-justify into 3 positions: M S1 S2
+    const padded = digits.padStart(3, "0");
+    const minutes = parseInt(padded[0]);
+    const seconds = parseInt(padded.slice(1));
+
+    if (seconds > 59 || minutes > 9) return null;
+
+    // Cap at period length
+    if (minutes > maxMinutes || (minutes === maxMinutes && seconds > 0)) return null;
+
+    return {
+        display: minutes + ":" + String(seconds).padStart(2, "0"),
+        stored: minutes + ":" + String(seconds).padStart(2, "0"),
+    };
+}
+
+/**
+ * Formats raw digit input into HTML for the time display.
+ *
+ * Right-to-left fill into M:S1S2 — placeholder is -:--.
+ * Unfilled positions show as dim placeholder dashes.
+ *
+ * @param {string} digits - Raw digit string (0-3 chars)
+ * @returns {string} HTML string with placeholder spans
+ */
+export function formatTimeDisplay(digits) {
+    // Right-to-left fill into M:S1S2 — placeholder is -:--
+    const padded = digits.padStart(3, "\0"); // pad with nulls
+    const parts = [];
+
+    for (let i = 0; i < 3; i++) {
+        if (padded[i] === "\0") {
+            parts.push(`<span class="time-placeholder">-</span>`);
+        } else {
+            parts.push(padded[i]);
+        }
+    }
+
+    // Colon is dim only when no digits entered
+    const colonClass = digits.length > 0 ? "" : ' class="time-placeholder"';
+
+    // Minutes placeholder shows for 0-2 digits, hidden when 3 digits (minutes filled)
+    return `<span class="time-formatted">${parts[0]}<span${colonClass}>:</span>${parts[1]}${parts[2]}</span>`;
+}

--- a/sw.js
+++ b/sw.js
@@ -31,6 +31,7 @@ const ASSETS = [
     "./js/config.js",
     "./js/confirm.js",
     "./js/storage.js",
+    "./js/time.js",
     "./js/game.js",
     "./js/setup.js",
     "./js/events.js",

--- a/tests/time.test.js
+++ b/tests/time.test.js
@@ -1,0 +1,182 @@
+/**
+ * Copyright 2026 Marko Milivojevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it } from "node:test";
+import { strictEqual, deepStrictEqual } from "node:assert";
+import { getMaxMinutes, parseTime, formatTimeDisplay } from "../js/time.js";
+
+// ── getMaxMinutes ─────────────────────────────────────────
+
+describe("getMaxMinutes", () => {
+    it("returns periodLength for regulation periods", () => {
+        strictEqual(getMaxMinutes(1, 8, 3), 8);
+        strictEqual(getMaxMinutes(2, 8, 3), 8);
+        strictEqual(getMaxMinutes(3, 7, 3), 7);
+        strictEqual(getMaxMinutes(4, 6, 3), 6);
+    });
+
+    it("returns otPeriodLength for OT periods", () => {
+        strictEqual(getMaxMinutes("OT1", 8, 3), 3);
+        strictEqual(getMaxMinutes("OT2", 8, 5), 5);
+        strictEqual(getMaxMinutes("OT3", 8, 4), 4);
+    });
+
+    it("returns 0 for SO", () => {
+        strictEqual(getMaxMinutes("SO", 8, 3), 0);
+    });
+
+    it("defaults periodLength to 8 when falsy", () => {
+        strictEqual(getMaxMinutes(1, 0, 3), 8);
+        strictEqual(getMaxMinutes(1, null, 3), 8);
+        strictEqual(getMaxMinutes(1, undefined, 3), 8);
+    });
+
+    it("defaults otPeriodLength to 3 when falsy", () => {
+        strictEqual(getMaxMinutes("OT1", 8, 0), 3);
+        strictEqual(getMaxMinutes("OT1", 8, null), 3);
+        strictEqual(getMaxMinutes("OT1", 8, undefined), 3);
+    });
+});
+
+// ── parseTime ─────────────────────────────────────────────
+
+describe("parseTime", () => {
+    it("returns null for empty input", () => {
+        strictEqual(parseTime("", 8), null);
+    });
+
+    it("parses single digit (seconds only)", () => {
+        deepStrictEqual(parseTime("4", 8), { display: "0:04", stored: "0:04" });
+        deepStrictEqual(parseTime("0", 8), { display: "0:00", stored: "0:00" });
+        deepStrictEqual(parseTime("9", 8), { display: "0:09", stored: "0:09" });
+    });
+
+    it("parses two digits (right-to-left fill)", () => {
+        deepStrictEqual(parseTime("45", 8), { display: "0:45", stored: "0:45" });
+        deepStrictEqual(parseTime("59", 8), { display: "0:59", stored: "0:59" });
+        deepStrictEqual(parseTime("00", 8), { display: "0:00", stored: "0:00" });
+        deepStrictEqual(parseTime("10", 8), { display: "0:10", stored: "0:10" });
+    });
+
+    it("parses three digits (M:SS)", () => {
+        deepStrictEqual(parseTime("453", 8), { display: "4:53", stored: "4:53" });
+        deepStrictEqual(parseTime("800", 8), { display: "8:00", stored: "8:00" });
+        deepStrictEqual(parseTime("100", 8), { display: "1:00", stored: "1:00" });
+        deepStrictEqual(parseTime("000", 8), { display: "0:00", stored: "0:00" });
+    });
+
+    it("rejects seconds > 59", () => {
+        strictEqual(parseTime("60", 8), null);
+        strictEqual(parseTime("99", 8), null);
+        strictEqual(parseTime("160", 8), null);
+    });
+
+    it("caps at period length", () => {
+        // 8-min quarter: 8:00 is valid, 8:01 is not
+        deepStrictEqual(parseTime("800", 8), { display: "8:00", stored: "8:00" });
+        strictEqual(parseTime("801", 8), null);
+        strictEqual(parseTime("830", 8), null);
+        strictEqual(parseTime("900", 8), null);
+
+        // 7-min quarter
+        deepStrictEqual(parseTime("700", 7), { display: "7:00", stored: "7:00" });
+        strictEqual(parseTime("701", 7), null);
+        strictEqual(parseTime("800", 7), null);
+
+        // 3-min OT
+        deepStrictEqual(parseTime("300", 3), { display: "3:00", stored: "3:00" });
+        strictEqual(parseTime("301", 3), null);
+        strictEqual(parseTime("400", 3), null);
+    });
+
+    it("rejects anything in SO (max 0)", () => {
+        deepStrictEqual(parseTime("000", 0), { display: "0:00", stored: "0:00" });
+        strictEqual(parseTime("1", 0), null);  // 0:01 > 0:00
+        strictEqual(parseTime("100", 0), null);
+    });
+
+    it("handles boundary: exactly at max", () => {
+        deepStrictEqual(parseTime("600", 6), { display: "6:00", stored: "6:00" });
+        deepStrictEqual(parseTime("559", 6), { display: "5:59", stored: "5:59" });
+    });
+});
+
+// ── formatTimeDisplay ─────────────────────────────────────
+
+describe("formatTimeDisplay", () => {
+    it("shows full placeholder for empty input", () => {
+        const result = formatTimeDisplay("");
+        strictEqual(
+            result,
+            '<span class="time-formatted">' +
+            '<span class="time-placeholder">-</span>' +
+            '<span class="time-placeholder">:</span>' +
+            '<span class="time-placeholder">-</span>' +
+            '<span class="time-placeholder">-</span>' +
+            '</span>'
+        );
+    });
+
+    it("fills one digit (rightmost position)", () => {
+        const result = formatTimeDisplay("4");
+        // M and S1 are placeholders, S2 is "4"
+        strictEqual(
+            result,
+            '<span class="time-formatted">' +
+            '<span class="time-placeholder">-</span>' +
+            '<span>:</span>' +
+            '<span class="time-placeholder">-</span>' +
+            '4' +
+            '</span>'
+        );
+    });
+
+    it("fills two digits", () => {
+        const result = formatTimeDisplay("45");
+        // M is placeholder, S1="4", S2="5"
+        strictEqual(
+            result,
+            '<span class="time-formatted">' +
+            '<span class="time-placeholder">-</span>' +
+            '<span>:</span>' +
+            '4' +
+            '5' +
+            '</span>'
+        );
+    });
+
+    it("fills three digits (all positions)", () => {
+        const result = formatTimeDisplay("453");
+        // M="4", S1="5", S2="3" — no placeholders
+        strictEqual(
+            result,
+            '<span class="time-formatted">' +
+            '4' +
+            '<span>:</span>' +
+            '5' +
+            '3' +
+            '</span>'
+        );
+    });
+
+    it("colon has placeholder class only when no digits", () => {
+        const empty = formatTimeDisplay("");
+        strictEqual(empty.includes('class="time-placeholder">:</span>'), true);
+
+        const one = formatTimeDisplay("1");
+        strictEqual(one.includes('<span>:</span>'), true);
+    });
+});


### PR DESCRIPTION
Extract _getMaxMinutes, _parseTime, _formatTimeDisplay from events.js
into a new pure module js/time.js with 18 Node tests.

- New: js/time.js (3 exported pure functions)
- New: tests/time.test.js (18 tests)
- Modified: js/events.js (thin delegation wrappers)
- Modified: sw.js (add time.js to ASSETS)
- Modified: AGENTS.md (architecture tree + What's Done)

Closes #143
