### PR TITLE
feat: Home/Away team designation with DEFAULTS centralization (#164)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ wplog/
 │   ├── sanitize.js    # escapeHTML() utility (ES module)
 │   ├── loader.js      # App shell loader — fetches screens, imports app module, inits app
 │   ├── year.js        # Copyright year display (standalone script, shared by all pages)
-│   ├── config.js       # APP_VERSION + RULES definitions (USAWP, NFHS Varsity, NFHS JV, NCAA)
+│   ├── config.js       # APP_VERSION + DEFAULTS + RULES definitions (USAWP, NFHS Varsity, NFHS JV, NCAA)
 │   ├── confirm.js      # Custom confirmation dialog (replaces native confirm())
 │   ├── storage.js      # localStorage wrapper (with schema validation)
 │   ├── game.js         # Core data model + game logic (pure — no Storage dependency)
@@ -163,10 +163,13 @@ These were explicitly discussed and agreed with the user:
 | **`statsOnly` flag** | Events with `statsOnly: true` skip foul-out checks, allow blank time, and are filtered from Progress of Game on sheet. |
 | **`statsTimeMode`** | Controls time field in modal: `"off"` = hidden, `"optional"` = shown but not required, `"on"` = required. Stored in game data model. |
 | **ES modules** | All JS files use native `import`/`export` (except `year.js` which is a standalone `<script defer>`). `loader.js` is loaded as `<script type="module">` and imports `app.js`, which imports all other modules. The browser resolves the dependency tree automatically — no manual load ordering. Service worker also uses `import` for `APP_VERSION` from `config.js`. |
+| **Home/Away designation** | `homeTeam` is a rule-set property in `config.json` (`_base` defaults to `"W"`, `_academic` overrides to `"D"`). Setup screen shows a ⇄ flip button to override per-game. Flip is locked during active games. All display surfaces (score bar, sheet header, Score by Period, Player Stats, CSV filename) render Home team first, Away second. Event modal button order (W/D) is fixed for muscle memory. |
+| **`DEFAULTS` object** | Centralized fallback defaults in `config.js` for all rule-set properties (`periods`, `periodLength`, `foulOutLimit`, `homeTeam`, `overtime`, `shootout`, `timeouts`, `events`, `statsEvents`). Used by `_getSafeMode()` and the normalization block. Eliminates scattered magic numbers. |
+| **Setup labels** | Team input labels show `"$location Team ($color)"` format — e.g., "Home Team (White)", "Away Team (Dark)". |
 
 ---
 
-## Current State (as of 2026-03-29)
+## Current State (as of 2026-03-30)
 
 ### What's Done ✅
 - Dynamic 10+ minute game clock support natively scales Numpad limit/UI dash format between 3-digit `M:SS` and 4-digit `MM:SS` modes depending on rule set, expanding config boundaries up to 20-minute periods/halves.
@@ -300,6 +303,9 @@ These were explicitly discussed and agreed with the user:
 - Input validation fixes: cap `"0"` rejected, time `"0:60"` rejected (seconds ≥ 60)
 - Dev server: `tools/serve.go` (Go stdlib) with correct MIME types for ES modules
 - Test data: realistic game fixtures in `testdata/` (small/medium/large) for NCAA and NFHS rule sets
+- Home/Away team designation: config-driven `homeTeam` per rule set (USAWP=White, NFHS/NCAA=Dark via `_academic`), flip button override on setup, all display surfaces (score bar, sheet, CSV) render Home first/Away second
+- `DEFAULTS` object in `config.js`: centralized fallback defaults for all rule-set properties, used by safe mode and normalization — zero scattered magic numbers
+- `DEFAULTS` imported as `{ RULES, DEFAULTS }` in game.js, setup.js, storage.js for consistent fallback handling
 
 ### Known Gaps / Future Work 📋
 - No substitution tracking (user hasn't decided)

--- a/config.json
+++ b/config.json
@@ -12,7 +12,11 @@
     { "name": "Sprint Won", "color": "teal", "statsOnly": true }
   ],
   "RULES": {
-    "_base": { "periods": 4, "foulOutLimit": 3 },
+    "_base": {
+      "periods": 4,
+      "foulOutLimit": 3,
+      "homeTeam": "W"
+    },
     "USAWP": {
       "inherits": "_base",
       "name": "USA Water Polo",
@@ -38,6 +42,7 @@
     "USAWP6": { "inherits": "USAWP", "name": "USA Water Polo (6 min)", "periodLength": 6 },
     "_academic": {
       "inherits": "_base",
+      "homeTeam": "D",
       "periodLength": 7,
       "otPeriodLength": 3,
       "overtime": true,

--- a/css/style.css
+++ b/css/style.css
@@ -186,7 +186,8 @@ body {
 .segment-btn:disabled,
 .stepper-btn:disabled,
 .btn:disabled,
-.modal-action-btn:disabled {
+.modal-action-btn:disabled,
+.home-flip-btn:disabled {
   opacity: 0.3;
   cursor: not-allowed;
 }
@@ -301,6 +302,31 @@ select.form-input {
 .form-row .form-group {
   flex: 1;
 }
+
+.home-flip-btn {
+  align-self: flex-end;
+  margin-bottom: 16px;
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  font-size: 18px;
+  cursor: pointer;
+  transition: all var(--transition);
+  touch-action: manipulation;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.home-flip-btn:hover {
+  border-color: var(--border-focus);
+  color: var(--accent-blue);
+}
+
 
 /* ============================
    Segmented Control

--- a/help.html
+++ b/help.html
@@ -22,7 +22,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Quick Reference Guide for wplog — Water Polo Game Log">
   <meta name="theme-color" content="#0a0e1a">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <title>Help — wplog</title>
@@ -45,7 +46,8 @@
         <li>Choose logging mode in <strong>Logging Mode</strong> (Game Log, Stats, or both)</li>
         <li>Tap <strong>Start Game</strong></li>
         <li>Log events from the <strong>Live</strong> screen</li>
-        <li>View the game sheet in <strong>Sheet</strong>; export CSV or download game data from <strong>Share</strong></li>
+        <li>View the game sheet in <strong>Sheet</strong>; export CSV or download game data from <strong>Share</strong>
+        </li>
       </ol>
     </div>
 
@@ -118,7 +120,8 @@
       <ul class="help-list">
         <li><strong>Sheet</strong> tab shows a printable game summary</li>
         <li>Tap <strong>CUMULATIVE / PER PERIOD</strong> on the sheet to toggle stat modes</li>
-        <li><strong>Share</strong> tab &rarr; <strong>Print Game Sheet</strong> to precisely select and print the Log, Stats, or Both</li>
+        <li><strong>Share</strong> tab &rarr; <strong>Print Game Sheet</strong> to precisely select and print the Log,
+          Stats, or Both</li>
         <li><strong>Download CSV</strong> or <strong>Download Game Data</strong> to export digital files</li>
       </ul>
     </div>
@@ -135,10 +138,15 @@
     <div class="help-section">
       <h2>Tips</h2>
       <ul class="help-list">
+        <li>Tap <strong>⇄</strong> on Setup to swap Home/Away team colors</li>
         <li>Tap a filled time or cap field to clear and re-enter</li>
         <li>Delete any event from the recent log with the ✕ button</li>
         <li>Setup fields (date, teams, etc.) stay editable during a game</li>
-        <li>On desktop, use the keyboard in the event dialog: digits for time/cap, <strong>A</strong>/<strong>B</strong>/<strong>C</strong> for letters, <strong>W</strong>/<strong>D</strong> for team, <strong>O</strong> for official, <strong>Tab</strong> to switch fields, <strong>Enter</strong> to confirm, <strong>Esc</strong> to cancel</li>
+        <li>On desktop, use the keyboard in the event dialog: digits for time/cap,
+          <strong>A</strong>/<strong>B</strong>/<strong>C</strong> for letters, <strong>W</strong>/<strong>D</strong>
+          for team, <strong>O</strong> for official, <strong>Tab</strong> to switch fields, <strong>Enter</strong> to
+          confirm, <strong>Esc</strong> to cancel
+        </li>
       </ul>
     </div>
 

--- a/js/config.js
+++ b/js/config.js
@@ -18,6 +18,26 @@
 // Default is "dev"; deploy workflow injects the release tag.
 export const APP_VERSION = "dev";
 
+// App-level defaults — fallbacks for missing rule-set properties
+export const DEFAULTS = {
+    periods: 4,
+    periodLength: 8,
+    foulOutLimit: 3,
+    homeTeam: "W",
+    overtime: false,
+    shootout: true,
+    timeouts: { full: 2, to30: 0 },
+    events: [
+        { name: "Goal", code: "G", color: "green", align: "left" },
+        { name: "Exclusion", code: "E", color: "amber", align: "right", isPersonalFoul: true },
+        { name: "Penalty", code: "P", color: "amber", align: "right", isPersonalFoul: true },
+        { name: "Timeout", code: "TO", color: "blue", align: "center", teamOnly: true }
+    ],
+    statsEvents: [
+        { name: "Shot", color: "teal", statsOnly: true }
+    ],
+};
+
 // wplog — Rules Configuration
 //
 // Each event has:
@@ -80,7 +100,7 @@ function _resolveRules(rulesObj, statsArr) {
         resolved.add(key);
     }
     for (const key of Object.keys(rulesObj)) resolve(key);
-    
+
     // 3. Apply removeEvents / addEvents directives
     for (const [key, rule] of Object.entries(rulesObj)) {
         rule.events = rule.events || [];
@@ -99,12 +119,12 @@ function _resolveRules(rulesObj, statsArr) {
             delete rule.addEvents;
         }
     }
-    
+
     // 4. Append STATS_EVENTS to every rule set
     for (const rule of Object.values(rulesObj)) {
         rule.events = [...(rule.events || []), ...statsArr];
     }
-    
+
     // 5. Auto-derive code from name for any event missing one
     for (const rule of Object.values(rulesObj)) {
         for (const evt of rule.events) {
@@ -115,18 +135,18 @@ function _resolveRules(rulesObj, statsArr) {
 
 function _getSafeMode() {
     return {
-        STATS_EVENTS: [],
+        STATS_EVENTS: [...DEFAULTS.statsEvents],
         RULES: {
             "SAFE": {
                 name: "Safe Mode (Config Error)",
-                periods: 4,
-                periodLength: 8,
-                foulOutLimit: 3,
-                events: [
-                    { name: "Goal", code: "G", color: "green", align: "left" },
-                    { name: "Exclusion", code: "E", color: "amber", align: "right", isPersonalFoul: true },
-                    { name: "Timeout", code: "TO", color: "blue", align: "center", teamOnly: true }
-                ]
+                periods: DEFAULTS.periods,
+                periodLength: DEFAULTS.periodLength,
+                foulOutLimit: DEFAULTS.foulOutLimit,
+                homeTeam: DEFAULTS.homeTeam,
+                overtime: DEFAULTS.overtime,
+                shootout: DEFAULTS.shootout,
+                timeouts: { ...DEFAULTS.timeouts },
+                events: [...DEFAULTS.events]
             }
         }
     };
@@ -153,9 +173,10 @@ export async function loadConfig() {
         if (typeof v !== 'object') continue;
         if (!v.events && !v.inherits) v.events = [];
         if (v.events && !Array.isArray(v.events)) v.events = [];
-        if (!v.periodLength && !v.inherits) v.periodLength = 8;
-        if (!v.periods && !v.inherits) v.periods = 4;
-        if (!v.foulOutLimit && !v.inherits) v.foulOutLimit = 3;
+        if (!v.periodLength && !v.inherits) v.periodLength = DEFAULTS.periodLength;
+        if (!v.periods && !v.inherits) v.periods = DEFAULTS.periods;
+        if (!v.foulOutLimit && !v.inherits) v.foulOutLimit = DEFAULTS.foulOutLimit;
+        if (!v.homeTeam && !v.inherits) v.homeTeam = DEFAULTS.homeTeam;
     }
 
     try {

--- a/js/events.js
+++ b/js/events.js
@@ -33,9 +33,11 @@ export const Events = {
     _numpadTarget: "time",  // "time" or "cap"
     _timeRaw: "",           // raw digits for time
     _capRaw: "",            // raw value for cap
+    _teams: null,           // [home, away] team descriptors
 
     init(game) {
         this.game = game;
+        this._initScoreBar();
         this._buildEventButtons();
         this._buildPeriodTabs();
         this._updateScoreBar();
@@ -46,6 +48,19 @@ export const Events = {
             this._boundModal = true;
         }
     },
+
+    // Apply team ordering to score bar based on homeTeam config
+    _initScoreBar() {
+        this._teams = Game.getTeams(this.game);
+        for (let i = 0; i < 2; i++) {
+            const t = this._teams[i];
+            document.getElementById(`score-label-${i}`).textContent = t.label.toUpperCase();
+            const container = document.getElementById(`score-team-${i}`);
+            container.classList.remove("score-team-white", "score-team-dark");
+            container.classList.add(`score-team-${t.cssClass}`);
+        }
+    },
+
 
     // ── Time Parsing ────────────────────────────────────────
     // Delegated to pure functions in time.js:
@@ -593,13 +608,16 @@ export const Events = {
 
     _updateScoreBar() {
         const score = Game.getDisplayScore(this.game);
-        document.getElementById("score-white").textContent = score.white;
-        document.getElementById("score-dark").textContent = score.dark;
+        for (let i = 0; i < 2; i++) {
+            const t = this._teams[i];
+            const val = t.code === "W" ? score.white : score.dark;
+            document.getElementById(`score-value-${i}`).textContent = val;
+        }
         document.getElementById("current-period").textContent = Game.getPeriodLabel(
             this.game.currentPeriod
         );
-        this._updateTOL("W", "tol-white");
-        this._updateTOL("D", "tol-dark");
+        this._updateTOL(this._teams[0].code, "tol-0");
+        this._updateTOL(this._teams[1].code, "tol-1");
     },
 
     _updateTOL(team, elementId) {

--- a/js/export.js
+++ b/js/export.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { Game } from './game.js';
+
 // wplog — Export Utilities (pure, no DOM)
 
 /**
@@ -38,12 +40,12 @@ export function buildFilename(game, ext) {
     const date = game.date || new Date().toISOString().slice(0, 10);
     parts.push(date);
 
-    // Teams (only if custom)
-    const w = game.white.name;
-    const d = game.dark.name;
-    if (w !== "White" || d !== "Dark") {
-        parts.push(sanitizeName(w !== "White" ? w : "White"));
-        parts.push(sanitizeName(d !== "Dark" ? d : "Dark"));
+    // Teams (only if custom) — ordered home-first
+    const teams = Game.getTeams(game);
+    const t0 = teams[0], t1 = teams[1];
+    if (t0.name !== t0.defaultName || t1.name !== t1.defaultName) {
+        parts.push(sanitizeName(t0.name !== t0.defaultName ? t0.name : t0.defaultName));
+        parts.push(sanitizeName(t1.name !== t1.defaultName ? t1.name : t1.defaultName));
     }
 
     // Time: startTime if set, else current time

--- a/js/game.js
+++ b/js/game.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { RULES } from './config.js';
+import { RULES, DEFAULTS } from './config.js';
 
 // wplog — Game State Management
 
@@ -38,6 +38,7 @@ export const Game = {
             overtime: rules.overtime,
             shootout: rules.shootout,
             timeoutsAllowed: { full: rules.timeouts.full, to30: rules.timeouts.to30 },
+            homeTeam: rules.homeTeam || DEFAULTS.homeTeam,
             enableLog: true,
             enableStats: false,
             statsTimeMode: "off",
@@ -48,6 +49,33 @@ export const Game = {
             _nextId: 1,
             _nextSeq: 10,
         };
+    },
+
+    /**
+     * Return [home, away] team descriptors for display ordering.
+     * Each descriptor: { code, label, name, defaultName, cssClass }
+     * @param {Object} game
+     * @returns {Array<{code: string, label: string, name: string, defaultName: string, cssClass: string}>}
+     */
+    getTeams(game) {
+        const homeCode = game.homeTeam || DEFAULTS.homeTeam;
+
+        const w = { code: "W", label: "White", name: game.white.name, defaultName: "White", cssClass: "white" };
+        const d = { code: "D", label: "Dark", name: game.dark.name, defaultName: "Dark", cssClass: "dark" };
+
+        return homeCode === "W" ? [w, d] : [d, w];
+    },
+
+    /**
+     * Return [home, away] team descriptors for a rules key (before a game exists).
+     * Uses default names.
+     * @param {string} rulesKey
+     * @returns {Array<{code: string, label: string, name: string, defaultName: string, cssClass: string}>}
+     */
+    getTeamsForRules() {
+        const w = { code: "W", label: "White", name: "White", defaultName: "White", cssClass: "white" };
+        const d = { code: "D", label: "Dark", name: "Dark", defaultName: "Dark", cssClass: "dark" };
+        return [w, d];
     },
 
     // Add an event to the game log
@@ -501,8 +529,8 @@ export const Game = {
             const eventDef = rules.events.find((e) => e.code === entry.event);
             const team = entry.team === "W" ? "White"
                 : entry.team === "D" ? "Dark"
-                : entry.team === "" ? "Official"
-                : "—";
+                    : entry.team === "" ? "Official"
+                        : "—";
             return {
                 team,
                 period: this.getPeriodLabel(entry.period),
@@ -583,7 +611,7 @@ export const Game = {
 
         // Print ALL available stats all the time for consistent layout and muscle memory
         const activeStatCodes = statTypes.map(st => st.code);
-        
+
         // Active periods for headers
         const activePeriods = this.getAllPeriods(game).map(p => this.getPeriodLabel(p));
 

--- a/js/setup.js
+++ b/js/setup.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { RULES } from './config.js';
+import { RULES, DEFAULTS } from './config.js';
 import { ConfirmDialog } from './confirm.js';
 import { Storage, validateGameData } from './storage.js';
 import { Game } from './game.js';
@@ -22,14 +22,21 @@ import { Game } from './game.js';
 // wplog — Setup Screen Logic
 
 export const Setup = {
+    _homeTeam: DEFAULTS.homeTeam,  // current home team code
+    _teams: null,    // [home, away] team descriptors
+    _bound: false,      // guard against duplicate event binding
+
     init(onStart) {
         this.onStart = onStart;
-        this._bindEvents();
-        this._bindSteppers();
+        if (!this._bound) {
+            this._bindEvents();
+            this._bindSteppers();
+            this._bindLoggingMode();
+            this._bound = true;
+        }
         this._resetForm();
         this._setDefaultDate();
         this._populateRules();
-        this._bindLoggingMode();
     },
 
     _resetForm() {
@@ -37,6 +44,7 @@ export const Setup = {
         document.getElementById("setup-start-btn").disabled = false;
         document.getElementById("setup-start-btn").textContent = "Start Game";
         document.getElementById("setup-rules").disabled = false;
+        document.getElementById("setup-home-flip").disabled = false;
 
         // Reset logging mode segmented control
         const modeControl = document.getElementById("setup-logging-mode");
@@ -71,6 +79,9 @@ export const Setup = {
     updateForActiveGame(game) {
         if (!game) return;
 
+        // Set home team from game data
+        this._homeTeam = game.homeTeam || DEFAULTS.homeTeam;
+
         // Populate form from game data
         document.getElementById("setup-rules").value = game.rules;
         document.getElementById("setup-date").value = game.date || "";
@@ -79,11 +90,21 @@ export const Setup = {
         timeEl.classList.toggle("has-value", !!timeEl.value);
         document.getElementById("setup-location").value = game.location || "";
         document.getElementById("setup-game-id").value = game.gameId || "";
-        document.getElementById("setup-white-name").value = game.white.name === "White" ? "" : game.white.name;
-        document.getElementById("setup-dark-name").value = game.dark.name === "Dark" ? "" : game.dark.name;
+
+        // Populate team inputs in home/away order
+        this._updateTeamLabels();
+        const teams = Game.getTeams(game);
+        for (let i = 0; i < 2; i++) {
+            const t = teams[i];
+            const val = t.code === "W" ? game.white.name : game.dark.name;
+            document.getElementById(`setup-team-${i}-name`).value = val === t.defaultName ? "" : val;
+        }
 
         // Hide Load Game button during active game
         document.getElementById("setup-load-btn").style.display = "none";
+
+        // Disable flip button during active game
+        document.getElementById("setup-home-flip").disabled = true;
 
         // Replace Start Game with End Game button
         const startBtn = document.getElementById("setup-start-btn");
@@ -125,14 +146,19 @@ export const Setup = {
         saveField("setup-time", () => { game.startTime = document.getElementById("setup-time").value; });
         saveField("setup-location", () => { game.location = document.getElementById("setup-location").value; });
         saveField("setup-game-id", () => { game.gameId = document.getElementById("setup-game-id").value.trim(); });
-        saveField("setup-white-name", () => {
-            const v = document.getElementById("setup-white-name").value.trim();
-            game.white.name = v || "White";
-        });
-        saveField("setup-dark-name", () => {
-            const v = document.getElementById("setup-dark-name").value.trim();
-            game.dark.name = v || "Dark";
-        });
+
+        // Live-save team names — map position-based inputs back to game.white/game.dark
+        for (let i = 0; i < 2; i++) {
+            const t = teams[i];
+            saveField(`setup-team-${i}-name`, () => {
+                const v = document.getElementById(`setup-team-${i}-name`).value.trim();
+                if (t.code === "W") {
+                    game.white.name = v || "White";
+                } else {
+                    game.dark.name = v || "Dark";
+                }
+            });
+        }
 
         // Logging mode — set active buttons and disable during active game
         const mode = game.enableLog && game.enableStats ? "full"
@@ -325,6 +351,10 @@ export const Setup = {
         const rulesKey = document.getElementById("setup-rules").value;
         const rules = RULES[rulesKey];
 
+        // Reset home team to rule set default
+        this._homeTeam = rules.homeTeam || DEFAULTS.homeTeam;
+        this._updateTeamLabels();
+
         // Post-regulation segmented control
         const prValue = rules.overtime ? "overtime" : rules.shootout ? "shootout" : "none";
         document.querySelectorAll("#setup-post-regulation .segment-btn").forEach((btn) => {
@@ -341,9 +371,38 @@ export const Setup = {
         this._updateGameSetupHeader();
     },
 
+    // Update team labels and placeholders based on _homeTeam
+    _updateTeamLabels() {
+        const w = { code: "W", label: "White" };
+        const d = { code: "D", label: "Dark" };
+        this._teams = this._homeTeam === "W" ? [w, d] : [d, w];
+
+        for (let i = 0; i < 2; i++) {
+            const t = this._teams[i];
+            const suffix = i === 0 ? "Home" : "Away";
+            document.getElementById(`setup-team-${i}-label`).textContent = `${suffix} Team (${t.label})`;
+            document.getElementById(`setup-team-${i}-name`).placeholder = t.label;
+        }
+    },
+
     _bindEvents() {
         document.getElementById("setup-rules").addEventListener("change", () => {
             this._updateToggles();
+        });
+
+        // Home/Away flip button
+        document.getElementById("setup-home-flip").addEventListener("click", () => {
+            // Capture current input values before flip
+            const val0 = document.getElementById("setup-team-0-name").value;
+            const val1 = document.getElementById("setup-team-1-name").value;
+
+            // Flip home team
+            this._homeTeam = this._homeTeam === "W" ? "D" : "W";
+            this._updateTeamLabels();
+
+            // Swap the input values so team names stay with their cap color
+            document.getElementById("setup-team-0-name").value = val1;
+            document.getElementById("setup-team-1-name").value = val0;
         });
 
         // Post-regulation segmented control
@@ -452,16 +511,25 @@ export const Setup = {
             to30: this._getStepperValue("setup-to-30"),
         };
 
+        // Home team
+        game.homeTeam = this._homeTeam;
+
         // Logging mode from segmented control
         const mode = this._getSelectedMode();
         game.enableLog = mode === "log" || mode === "full";
         game.enableStats = mode === "full" || mode === "stats";
         game.statsTimeMode = this._getStatsTimeMode();
 
-        const whiteName = document.getElementById("setup-white-name").value.trim();
-        const darkName = document.getElementById("setup-dark-name").value.trim();
-        if (whiteName) game.white.name = whiteName;
-        if (darkName) game.dark.name = darkName;
+        // Read team names from position-based inputs, map back to white/dark
+        for (let i = 0; i < 2; i++) {
+            const t = this._teams[i];
+            const v = document.getElementById(`setup-team-${i}-name`).value.trim();
+            if (t.code === "W") {
+                if (v) game.white.name = v;
+            } else {
+                if (v) game.dark.name = v;
+            }
+        }
 
         Storage.save(game);
         this.onStart(game);

--- a/js/sheet.js
+++ b/js/sheet.js
@@ -57,9 +57,17 @@ export const Sheet = {
         const header = document.createElement("div");
         header.className = "sheet-header";
 
-        const whiteName = game.white.name === "White" ? "" : game.white.name;
-        const darkName = game.dark.name === "Dark" ? "" : game.dark.name;
+        const teams = Game.getTeams(game);
         const score = Game.getDisplayScore(game);
+
+        // Build team labels: home first, away second
+        const teamDivs = teams.map(t => {
+            const customName = t.name === t.defaultName ? "" : t.name;
+            return `<div class="sheet-team sheet-team-${t.cssClass}">
+          <span class="sheet-team-label">${escapeHTML(t.label)}</span>
+          <span class="sheet-team-name">${escapeHTML(customName)}</span>
+        </div>`;
+        });
 
         header.innerHTML = `
       <div class="sheet-title-row">
@@ -79,15 +87,9 @@ export const Sheet = {
         </div>
       </div>
       <div class="sheet-teams">
-        <div class="sheet-team sheet-team-white">
-          <span class="sheet-team-label">White</span>
-          <span class="sheet-team-name">${escapeHTML(whiteName)}</span>
-        </div>
-        <div class="sheet-final-score">${escapeHTML(score.white)} — ${escapeHTML(score.dark)}</div>
-        <div class="sheet-team sheet-team-dark">
-          <span class="sheet-team-label">Dark</span>
-          <span class="sheet-team-name">${escapeHTML(darkName)}</span>
-        </div>
+        ${teamDivs[0]}
+        <div class="sheet-final-score">${escapeHTML(String(teams[0].code === "W" ? score.white : score.dark))} — ${escapeHTML(String(teams[1].code === "W" ? score.white : score.dark))}</div>
+        ${teamDivs[1]}
       </div>
     `;
         return header;
@@ -167,11 +169,14 @@ export const Sheet = {
         thead.innerHTML = `<tr><th>Team</th>${headerCells}<th>Total</th></tr>`;
         table.appendChild(thead);
 
+        const teams = Game.getTeams(game);
         const tbody = document.createElement("tbody");
 
-        for (const [label, scores, total] of [["White", data.white, data.totalWhite], ["Dark", data.dark, data.totalDark]]) {
+        for (const t of teams) {
+            const scores = t.code === "W" ? data.white : data.dark;
+            const total = t.code === "W" ? data.totalWhite : data.totalDark;
             const tr = document.createElement("tr");
-            let cells = `<td class="sheet-team-cell">${label}</td>`;
+            let cells = `<td class="sheet-team-cell">${t.label}</td>`;
             for (const count of scores) {
                 cells += `<td>${String(count)}</td>`;
             }
@@ -349,11 +354,14 @@ export const Sheet = {
         const wName = game.white.name === "White" ? "White" : `White (${game.white.name})`;
         const dName = game.dark.name === "Dark" ? "Dark" : `Dark (${game.dark.name})`;
 
-        const wWrapper = this._renderTeamStatsTable(wName, data.stats.W, data.totals.W, data.statsPerPeriod.W, data.totalsPerPeriod.W, data.activeStatCodes, data.statTypes, data.activePeriods, formatStr);
-        section.appendChild(wWrapper);
-
-        const dWrapper = this._renderTeamStatsTable(dName, data.stats.D, data.totals.D, data.statsPerPeriod.D, data.totalsPerPeriod.D, data.activeStatCodes, data.statTypes, data.activePeriods, formatStr);
-        section.appendChild(dWrapper);
+        // Render in home-first order
+        const teams = Game.getTeams(game);
+        for (const t of teams) {
+            const teamCode = t.code;
+            const teamName = teamCode === "W" ? wName : dName;
+            const wrapper = this._renderTeamStatsTable(teamName, data.stats[teamCode], data.totals[teamCode], data.statsPerPeriod[teamCode], data.totalsPerPeriod[teamCode], data.activeStatCodes, data.statTypes, data.activePeriods, formatStr);
+            section.appendChild(wrapper);
+        }
 
         return section;
     },

--- a/js/storage.js
+++ b/js/storage.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { RULES } from './config.js';
+import { RULES, DEFAULTS } from './config.js';
 
 // wplog — localStorage Persistence + Game Data Validation
 
@@ -124,6 +124,11 @@ export function validateGameData(parsed) {
         const validStatsTimeModes = ["off", "optional", "on"];
         if (!_isString(parsed.statsTimeMode) || !validStatsTimeModes.includes(parsed.statsTimeMode)) {
             return _fail("statsTimeMode must be 'off', 'optional', or 'on'.");
+        }
+
+        // homeTeam (optional, defaults to "W")
+        if (parsed.homeTeam != null && parsed.homeTeam !== "W" && parsed.homeTeam !== "D") {
+            return _fail("homeTeam must be 'W' or 'D'.");
         }
 
         // white, dark (required objects with name)
@@ -248,6 +253,7 @@ export function validateGameData(parsed) {
             enableLog: parsed.enableLog,
             enableStats: parsed.enableStats,
             statsTimeMode: parsed.statsTimeMode,
+            homeTeam: parsed.homeTeam || DEFAULTS.homeTeam,
             white: { name: parsed.white.name },
             dark: { name: parsed.dark.name },
             currentPeriod: parsed.currentPeriod,

--- a/screens/live.html
+++ b/screens/live.html
@@ -16,18 +16,18 @@
 
 <!-- Score Bar -->
 <div class="score-bar">
-  <div class="score-team score-team-white">
-    <span class="score-label">WHITE</span>
-    <span id="score-white" class="score-value">0</span>
-    <span id="tol-white" class="tol-display"></span>
+  <div class="score-team" id="score-team-0">
+    <span class="score-label" id="score-label-0"></span>
+    <span id="score-value-0" class="score-value">0</span>
+    <span id="tol-0" class="tol-display"></span>
   </div>
   <div class="score-period">
     <span id="current-period" class="period-badge">Q1</span>
   </div>
-  <div class="score-team score-team-dark">
-    <span class="score-label">DARK</span>
-    <span id="score-dark" class="score-value">0</span>
-    <span id="tol-dark" class="tol-display"></span>
+  <div class="score-team" id="score-team-1">
+    <span class="score-label" id="score-label-1"></span>
+    <span id="score-value-1" class="score-value">0</span>
+    <span id="tol-1" class="tol-display"></span>
   </div>
 </div>
 

--- a/screens/setup.html
+++ b/screens/setup.html
@@ -23,14 +23,15 @@
   <select id="setup-rules" class="form-input"></select>
 </div>
 
-<div class="form-row">
+<div class="form-row" id="setup-team-row">
   <div class="form-group">
-    <label for="setup-white-name">White Team</label>
-    <input id="setup-white-name" type="text" class="form-input" placeholder="White">
+    <label id="setup-team-0-label"></label>
+    <input id="setup-team-0-name" type="text" class="form-input">
   </div>
+  <button type="button" id="setup-home-flip" class="home-flip-btn" title="Flip Home/Away">⇄</button>
   <div class="form-group">
-    <label for="setup-dark-name">Dark Team</label>
-    <input id="setup-dark-name" type="text" class="form-input" placeholder="Dark">
+    <label id="setup-team-1-label"></label>
+    <input id="setup-team-1-name" type="text" class="form-input">
   </div>
 </div>
 


### PR DESCRIPTION
- Config-driven homeTeam per rule set (_base=W, _academic=D)
- Flip button on setup to override home/away per-game (locked during game)
- All display surfaces render Home first, Away second (score bar, sheet, CSV)
- Event modal button order (W/D) fixed for muscle memory
- DEFAULTS object in config.js: centralized fallbacks for all rule-set properties
- Safe mode references DEFAULTS exclusively (zero hardcoded magic numbers)
- Setup labels: 'Home Team (White)' / 'Away Team (Dark)' format
- Score by Period and Player Stats on sheet follow home/away ordering
