### PR TITLE
feat: migrate all overlays to native dialog elements (#153)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 - **Personal fouls are config-driven** — use `isPersonalFoul: true` on events. Don't hardcode event codes for foul counting.
 - **MAM is a dual-trigger event** — `isPersonalFoul: true` + `autoFoulOut: 2`. This pattern was explicitly designed for NFHS/NCAA.
 - **Version system** — `APP_VERSION` lives in `config.js`. Default is `"dev"`. Deploy workflow injects release tag. Dev mode auto-detects file timestamp via `HEAD` requests. Don't hardcode versions elsewhere.
-- **About is an overlay** — not a screen/section. It uses the same `.overlay` pattern as `ConfirmDialog` and the foul-out popup.
+- **About is a native dialog** — not a screen/section. Uses native `<dialog>` element with `showModal()`/`close()`. All overlays (About, Confirm, Alert, Content, Download, Print, QR, Event Modal) are native `<dialog>` elements.
 - **Always use `escapeHTML()`** — when building `innerHTML` templates with user-supplied data (team names, cap numbers, Game #, location, etc.), wrap them in `escapeHTML()`. This is mandatory — see `sanitize.js`.
 
 
@@ -34,7 +34,7 @@
 
 ```
 wplog/
-├── index.html          # App shell (overlays, nav, empty screen placeholders + async loader)
+├── index.html          # App shell (native dialogs, nav, empty screen placeholders + async loader)
 ├── screens/
 │   ├── setup.html      # Setup screen content (rules, date, teams, etc.)
 │   ├── live.html       # Live log screen content (score bar, event buttons, log)
@@ -50,7 +50,8 @@ wplog/
 │   ├── loader.js      # App shell loader — fetches screens, imports app module, inits app
 │   ├── year.js        # Copyright year display (standalone script, shared by all pages)
 │   ├── config.js       # APP_VERSION + DEFAULTS + RULES definitions (USAWP, NFHS Varsity, NFHS JV, NCAA)
-│   ├── confirm.js      # Custom confirmation dialog (replaces native confirm())
+│   ├── confirm.js      # Custom confirmation dialog (replaces native confirm(), uses dialog.js)
+│   ├── dialog.js       # Shared dialog utilities (initDialog — backdrop click + dismiss button)
 │   ├── storage.js      # localStorage wrapper (with schema validation)
 │   ├── game.js         # Core data model + game logic (pure — no Storage dependency)
 │   ├── setup.js        # Setup screen (with active-game guards)
@@ -134,7 +135,7 @@ These were explicitly discussed and agreed with the user:
 | **`allowOfficial` flag** | Config-driven flag (valid on `teamOnly` events only). Shows a third "OFFICIAL" team toggle button in the modal. Selecting it stores `team: ""` — no new team code. TOL counting naturally excludes official timeouts. `O` keyboard shortcut. Button order: WHITE → OFFICIAL → DARK (Dark stays rightmost for muscle memory). |
 | **No `#` in Cap display** | Cap numbers shown without `#` prefix everywhere (modal, live log, sheet tables). |
 | **Score on Goals only** | Score column in game log (live + sheet) only shows on Goal events. Other events leave it empty. |
-| **Responsive modal** | Full-screen on mobile (default), fixed centered dialog on desktop (`@media min-width:900px and min-height:700px`). |
+| **Responsive modal** | Compact content-sized on mobile (default), fixed centered 480px dialog on desktop (`@media min-width:900px and min-height:700px`). Numpad button height capped at 72px for landscape aspect ratio. |
 | **Numpad layout** | 4 columns: digits 1-9/0, A/B/C in rightmost column, backspace next to 0. |
 | **Auto-close disabled** | GitHub auto-close via commit messages is disabled in this repo. Close issues manually with `gh issue close`. |
 | **Don't commit without confirmation** | Always wait for user to confirm before committing and pushing. |
@@ -143,9 +144,9 @@ These were explicitly discussed and agreed with the user:
 | **Help docs as delivery** | User-facing documentation (`help.html`) is part of feature delivery. Bazinga establishes the principle; geronimo and kraken enforce it with check steps. |
 | **Branching strategy** | Single-track: all work uses short-lived `fix/<name>` or `feature/<name>` branches off `main`. No parallel development branches. See the `branching` skill (`.agents/skills/branching/SKILL.md`). |
 | **Auto-clear on refocus** | Tapping a filled time/cap field in the modal auto-clears it for re-entry. Only on user clicks, not auto-advance. |
-| **Custom dialogs** | All `confirm()` calls replaced with `ConfirmDialog` (overlay-based). Supports `danger` (red) and `warning` (amber) types. |
+| **Custom dialogs** | All UI overlays use native HTML5 `<dialog>` elements with `showModal()`/`close()`. Shared `initDialog()` utility in `dialog.js` handles backdrop-click-to-close and dismiss-button wiring. No manual z-index, `.visible` class toggling, or position:fixed stacking. |
 | **Version system** | `APP_VERSION = "dev"` in `config.js`. Deploy workflow injects the release tag. In dev, runtime auto-detects latest file modification timestamp via `Last-Modified` HTTP headers → displays `dev-YYYYMMDD-HHMM`. No git or build step needed at runtime. |
-| **About dialog** | Overlay popup (not a screen) accessible via footer "About" link. Shows version, license, author, source link. |
+| **About dialog** | Native `<dialog>` popup (not a screen) accessible via footer "About" link. Shows version, license, author, source link. Privacy and License open as stacked content dialogs on top. |
 | **SW cache = version** | Service worker cache name is `"wplog-" + APP_VERSION`. Each release busts stale caches automatically. |
 | **SW dev vs prod** | Service worker uses network-first strategy in dev mode (no stale cache issues) and cache-first in production (offline reliability). |
 | **QR code sharing** | Single SVG (`img/qr-wplog.svg`) with white modules on transparent background. CSS `filter: invert(1)` for high-contrast overlay. Share screen always accessible. |
@@ -169,7 +170,7 @@ These were explicitly discussed and agreed with the user:
 
 ---
 
-## Current State (as of 2026-03-30)
+## Current State (as of 2026-03-31)
 
 ### What's Done ✅
 - Dynamic 10+ minute game clock support natively scales Numpad limit/UI dash format between 3-digit `M:SS` and 4-digit `MM:SS` modes depending on rule set, expanding config boundaries up to 20-minute periods/halves.
@@ -178,7 +179,11 @@ These were explicitly discussed and agreed with the user:
 - Added intelligent JavaScript print hook via `window.beforeprint`/`window.afterprint` to dynamically broaden the Player Stats matrix from 11 columns on screen to 22 columns on printed page without breaking responsive structure.
 - CSS consolidation: Eliminated obsolete CSS filter hacks, adopted explicit `--accent-blue`/`--text-on-accent` design tokens for native theme readiness, and stripped defunct `.toggle-row` selectors.
 - Unified `.dialog-card` styling architecture eliminating duplicate popup layouts.
-- Universal layout-aware keyboard event router for all overlay dialogs (`Escape` to close, `Enter` to confirm).
+- Native `<dialog>` migration: all 9 overlays converted from custom `<div class="overlay">` to native `<dialog>` elements with `showModal()`/`close()`, eliminating manual z-index stacking, `.visible` class toggling, and position:fixed management.
+- Shared `initDialog()` utility in `dialog.js`: centralizes backdrop-click-to-close and dismiss-button wiring — used by 6 dialogs (About, Content, Alert, Confirm, Download, Print).
+- Privacy and License dialogs consolidated into a single reusable `content-dialog` with cached content fetching — stacks natively on top of About dialog.
+- Compact event modal on mobile: content-sized height (no forced 100dvh), numpad buttons capped at 72px for landscape aspect ratio.
+- Modal auto-focus fix: `tabindex="-1" autofocus` on content wrapper absorbs `showModal()` focus, preventing spurious focus rings on first button.
 - Dynamic SVG Injection: Replaced static `<img>` tags with asynchronous `DOMParser("image/svg+xml")` instantiations to bypass iOS Safari namespace bugs and support native `fill` targeting.
 - Ghost text interactive inline toggles for Player Stats view (`CUMULATIVE / PER PERIOD`), dynamically synced with Print dialog state and natively stripped during CSS printing.
 - Complete setup screen (rules, date, time, location, Game #, team names, OT/SO toggles, timeout overrides)
@@ -222,7 +227,7 @@ These were explicitly discussed and agreed with the user:
 - "Geronimo" workflow for quick commit/push/close
 - Custom confirmation dialog (`ConfirmDialog`) replacing all native `confirm()` calls
 - Version display in footer (`APP_VERSION` with auto dev timestamp detection)
-- About dialog (overlay popup from footer link: version, license, author, source)
+- About dialog (native `<dialog>` popup from footer link: version, license, author, source)
 - Service worker cache name tied to `APP_VERSION` for automatic cache busting
 - Deploy-time version injection via `sed` in `deploy.yml`
 - QR code on Share screen for app URL sharing (single SVG, CSS-controlled colors)
@@ -236,7 +241,7 @@ These were explicitly discussed and agreed with the user:
 - File-per-screen architecture: `index.html` is app shell, content in `screens/*.html` loaded via async loader
 - Shared `css/standalone.css` for standalone pages (`privacy.html`, `help.html`)
 - Unified `.fetched-content` class for privacy + help content styles
-- Shared `.overlay-title`/`.overlay-message` base classes for all overlay dialogs
+- Shared `.overlay-title`/`.overlay-message` base classes for dialog content
 - Consistent `letter-spacing: 0.04em` on all uppercase labels app-wide
 - Consistent `opacity: 0.3` on all disabled elements
 - Version link in About dialog: links to GitHub release page in production, plain text in dev
@@ -280,7 +285,7 @@ These were explicitly discussed and agreed with the user:
 - JSON export: Download Game Data button on Share screen (compact JSON, shared filename dialog with CSV)
 - Load Game: button on Setup screen (visible when no game active), file picker for JSON, 5-layer validation
 - Input validation: `validateGameData()` in `storage.js` — file size limit (128 KB), schema checks, property stripping, allowlisted fields only
-- Error dialog for invalid load files (foul-out overlay pattern with specific error messages)
+- Error dialog for invalid load files (alert-dialog pattern with specific error messages)
 - Screen persistence: active screen restored across page reloads via `sessionStorage`
 - Game Setup section uses stepper controls for period length, OT length, and timeout limits (with ∞ option)
 - Stepper boundary protection: dec disabled at min, inc disabled at max (non-unlimited), defensive min/max guards in click handlers, init ordering ensures disable states aren't overwritten

--- a/css/print.css
+++ b/css/print.css
@@ -37,8 +37,6 @@
     --text-on-accent: #000000;
     
     --border: #000000;
-    
-    --overlay-bg: transparent;
 
     /* Force all accent and team colors to monochrome for print */
     --accent-blue: #000000;
@@ -72,7 +70,7 @@
   .nav-bar,
   .app-footer,
   #toast-container,
-  .overlay {
+  dialog {
     display: none !important;
   }
 

--- a/css/style.css
+++ b/css/style.css
@@ -132,6 +132,10 @@
   padding: 0;
 }
 
+dialog {
+  margin: auto;
+}
+
 html {
   font-size: 16px;
   -webkit-tap-highlight-color: transparent;
@@ -690,7 +694,7 @@ select.form-input {
 .numpad {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  grid-auto-rows: 1fr;
+  grid-auto-rows: minmax(48px, 72px);
   gap: 1dvh;
   flex: 1;
   min-height: 0;
@@ -931,44 +935,38 @@ select.form-input {
 .log-entry.event-border-teal { border-left: 3px solid var(--event-stat); }
 
 /* ============================
-   Foul-Out Overlay
+   Dialog System (native <dialog>)
    ============================ */
-.overlay {
-  position: fixed;
-  inset: 0;
-  background: var(--overlay-bg);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 200;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 200ms ease;
-  backdrop-filter: blur(4px);
-}
-
-.overlay.visible {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.overlay-content {
+.dialog {
+  border: none;
   background: var(--bg-card);
-  border: 1px solid var(--border);
   border-radius: var(--radius-xl);
   padding: 32px 24px;
   text-align: center;
-  max-width: 340px;
-  width: 90%;
+  width: min(90%, 340px);
+  margin: auto;
   box-shadow: var(--shadow-lg);
+  color: var(--text-primary);
+  animation: dialog-in 200ms ease;
+}
+
+.dialog::backdrop {
+  background: var(--overlay-bg);
+  backdrop-filter: blur(4px);
+}
+
+@keyframes dialog-in {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 .foulout-card {
+  border: 1px solid var(--border);
   border-color: var(--danger);
   box-shadow: var(--shadow-lg), 0 0 40px var(--danger-bg);
 }
 
-/* Shared overlay title + message */
+/* Shared dialog title + message */
 .overlay-title {
   font-size: 20px;
   font-weight: 800;
@@ -984,15 +982,12 @@ select.form-input {
   line-height: 1.5;
 }
 
-/* Foul-out overlay */
+/* Foul-out title */
 .foulout-title {
   color: var(--danger);
 }
 
 /* Confirm dialog */
-.confirm-card {
-  max-width: 340px;
-}
 
 .confirm-title {
   font-size: 18px;
@@ -1033,26 +1028,21 @@ select.form-input {
 .confirm-btn-warning:hover {
   box-shadow: var(--shadow-md), 0 0 16px var(--warning-glow-hover);
 }
+
 /* ============================
    Event Modal
    ============================ */
 .event-modal {
-  position: fixed;
-  inset: 0;
-  background: var(--overlay-bg);
-  display: flex;
-  align-items: stretch;
-  justify-content: center;
-  z-index: 150;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 200ms ease;
-  backdrop-filter: blur(4px);
-}
-
-.event-modal.visible {
-  opacity: 1;
-  pointer-events: auto;
+  max-width: none;
+  width: 100%;
+  height: fit-content;
+  max-height: 100dvh;
+  margin: auto 0;
+  border-radius: 0;
+  padding: 0;
+  background: transparent;
+  text-align: left;
+  animation: none;
 }
 
 .event-modal-content {
@@ -1061,19 +1051,11 @@ select.form-input {
   border-radius: 0;
   padding: 2dvh 16px 2dvh;
   width: 100%;
-  height: 100dvh;
   overflow-y: auto;
-  transform: translateY(20px);
-  opacity: 0;
-  transition: transform 250ms ease, opacity 250ms ease;
   box-shadow: var(--shadow-lg);
   display: flex;
   flex-direction: column;
-}
-
-.event-modal.visible .event-modal-content {
-  transform: translateY(0);
-  opacity: 1;
+  outline: none;
 }
 
 /* Modal event title */
@@ -1160,7 +1142,7 @@ select.form-input {
   top: 12px;
   left: 50%;
   transform: translateX(-50%);
-  z-index: 300;
+  z-index: 2147483647;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -1481,12 +1463,13 @@ select.form-input {
   transform: scale(1.03);
 }
 
-.qr-overlay {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.qr-dialog {
+  max-width: none;
+  width: auto;
+  background: transparent;
   padding: 24px;
   cursor: pointer;
+  animation: none;
 }
 
 .qr-fullscreen-wrap {
@@ -1876,7 +1859,12 @@ select.form-input {
    ============================ */
 @media (min-width: 900px) and (min-height: 700px) {
   .event-modal {
-    align-items: center;
+    width: min(90%, 480px);
+    height: fit-content;
+    max-height: 85vh;
+    margin: auto;
+    border-radius: var(--radius-xl);
+    animation: dialog-in 200ms ease;
   }
 
   .event-modal-content {

--- a/index.html
+++ b/index.html
@@ -42,121 +42,101 @@
   <!-- Toast Container -->
   <div id="toast-container"></div>
 
-  <!-- Foul-Out Overlay -->
-  <div id="foulout-overlay" class="overlay">
-    <div class="overlay-content foulout-card">
-      <div id="foulout-title" class="overlay-title foulout-title"></div>
-      <div id="foulout-message" class="overlay-message"></div>
-      <button id="foulout-dismiss" class="btn btn-primary">Dismiss</button>
-    </div>
-  </div>
+  <!-- Alert Dialog (foul-outs, load errors) -->
+  <dialog id="alert-dialog" class="dialog foulout-card">
+    <div id="alert-title" class="overlay-title foulout-title"></div>
+    <div id="alert-message" class="overlay-message"></div>
+    <button id="alert-dismiss" class="btn btn-primary">Dismiss</button>
+  </dialog>
 
   <!-- Confirm Dialog -->
-  <div id="confirm-overlay" class="overlay">
-    <div class="overlay-content confirm-card">
-      <div id="confirm-title" class="overlay-title confirm-title"></div>
-      <div id="confirm-message" class="overlay-message confirm-message"></div>
-      <div class="confirm-actions">
-        <button id="confirm-cancel" class="btn btn-outline confirm-action-btn">Cancel</button>
-        <button id="confirm-ok" class="btn confirm-action-btn">OK</button>
-      </div>
+  <dialog id="confirm-dialog" class="dialog">
+    <div id="confirm-title" class="overlay-title confirm-title"></div>
+    <div id="confirm-message" class="overlay-message confirm-message"></div>
+    <div class="confirm-actions">
+      <button id="confirm-cancel" class="btn btn-outline confirm-action-btn">Cancel</button>
+      <button id="confirm-ok" class="btn confirm-action-btn">OK</button>
     </div>
-  </div>
+  </dialog>
 
   <!-- About Dialog -->
-  <div id="about-overlay" class="overlay">
-    <div class="overlay-content dialog-card">
-      <div class="about-title">wplog</div>
-      <div class="about-subtitle">Water Polo Game Log</div>
-      <div class="about-info">
-        <div class="about-row">
-          <span class="about-label">Version</span>
-          <span class="about-value" id="about-version"></span>
-        </div>
-        <div class="about-row">
-          <span class="about-label">License</span>
-          <span class="about-value"><a href="#" id="about-license-link">Apache 2.0</a></span>
-        </div>
-        <div class="about-row">
-          <span class="about-label">Privacy</span>
-          <span class="about-value"><a href="#" id="about-privacy-link">Policy</a></span>
-        </div>
-        <div class="about-row">
-          <span class="about-label">Source</span>
-          <span class="about-value"><a href="https://github.com/icemarkom/wplog" target="_blank"
-              rel="noopener">GitHub</a></span>
-        </div>
-        <div class="about-row">
-          <span class="about-label">Author</span>
-          <span class="about-value"><a href="https://icemarkom.dev/" target="_blank" rel="noopener">Marko Milivojevic</a></span>
-        </div>
+  <dialog id="about-dialog" class="dialog dialog-card">
+    <div class="about-title">wplog</div>
+    <div class="about-subtitle">Water Polo Game Log</div>
+    <div class="about-info">
+      <div class="about-row">
+        <span class="about-label">Version</span>
+        <span class="about-value" id="about-version"></span>
       </div>
-      <p class="about-description">Log water polo game events poolside and produce official looking game sheets.</p>
-      <button id="about-dismiss" class="btn btn-primary about-dismiss-btn">Close</button>
+      <div class="about-row">
+        <span class="about-label">License</span>
+        <span class="about-value"><a href="#" id="about-license-link">Apache 2.0</a></span>
+      </div>
+      <div class="about-row">
+        <span class="about-label">Privacy</span>
+        <span class="about-value"><a href="#" id="about-privacy-link">Policy</a></span>
+      </div>
+      <div class="about-row">
+        <span class="about-label">Source</span>
+        <span class="about-value"><a href="https://github.com/icemarkom/wplog" target="_blank"
+            rel="noopener">GitHub</a></span>
+      </div>
+      <div class="about-row">
+        <span class="about-label">Author</span>
+        <span class="about-value"><a href="https://icemarkom.dev/" target="_blank" rel="noopener">Marko Milivojevic</a></span>
+      </div>
     </div>
-  </div>
+    <p class="about-description">Log water polo game events poolside and produce official looking game sheets.</p>
+    <button id="about-dismiss" class="btn btn-primary about-dismiss-btn">Close</button>
+  </dialog>
 
-  <!-- Privacy Policy Dialog -->
-  <div id="privacy-overlay" class="overlay">
-    <div class="overlay-content privacy-card">
-      <div id="privacy-body" class="privacy-body fetched-content"></div>
-      <button id="privacy-dismiss" class="btn btn-primary privacy-dismiss-btn">OK</button>
-    </div>
-  </div>
-
-  <!-- License Overlay -->
-  <div id="license-overlay" class="overlay">
-    <div class="overlay-content privacy-card">
-      <div id="license-body" class="license-body fetched-content"></div>
-      <button id="license-dismiss" class="btn btn-primary privacy-dismiss-btn">OK</button>
-    </div>
-  </div>
+  <!-- Content Dialog (shared: privacy, license) -->
+  <dialog id="content-dialog" class="dialog privacy-card">
+    <div id="content-body" class="fetched-content"></div>
+    <button id="content-dismiss" class="btn btn-primary privacy-dismiss-btn">OK</button>
+  </dialog>
 
   <!-- Download Dialog (shared by CSV and JSON exports) -->
-  <div id="download-overlay" class="overlay">
-    <div class="overlay-content dialog-card">
-      <div id="download-title" class="overlay-title dialog-title">Download</div>
-      <label for="download-filename" class="sr-only">Filename</label>
-      <input type="text" id="download-filename" class="download-filename" spellcheck="false" autocomplete="off">
-      <div class="dialog-actions">
-        <button id="download-confirm" class="btn btn-primary btn-large">Download</button>
-        <button id="download-cancel" class="btn-link">Cancel</button>
-      </div>
+  <dialog id="download-dialog" class="dialog dialog-card">
+    <div id="download-title" class="overlay-title dialog-title">Download</div>
+    <label for="download-filename" class="sr-only">Filename</label>
+    <input type="text" id="download-filename" class="download-filename" spellcheck="false" autocomplete="off">
+    <div class="dialog-actions">
+      <button id="download-confirm" class="btn btn-primary btn-large">Download</button>
+      <button id="download-cancel" class="btn-link">Cancel</button>
     </div>
-  </div>
+  </dialog>
 
   <!-- Print Sheet Dialog -->
-  <div id="print-overlay" class="overlay">
-    <div class="overlay-content dialog-card">
-      <div class="overlay-title dialog-title">Print Game Sheet</div>
-      <div class="form-group print-form-group">
-        <label id="label-print-sections">Sections to Print</label>
-        <div id="print-sections-mode" class="segment-control" aria-labelledby="label-print-sections">
-          <button type="button" class="segment-btn" data-value="log">Game Log</button>
-          <button type="button" class="segment-btn active" data-value="both">Both</button>
-          <button type="button" class="segment-btn" data-value="stats">Stats</button>
-        </div>
-      </div>
-      <div class="form-group print-form-group" id="print-stats-format-group">
-        <label id="label-print-format">Stats Format</label>
-        <div id="print-stats-format" class="segment-control" aria-labelledby="label-print-format">
-          <button type="button" class="segment-btn active" data-value="cumulative">Cumulative</button>
-          <button type="button" class="segment-btn" data-value="per-period">Per Period</button>
-        </div>
-      </div>
-      <div class="dialog-actions">
-        <button id="print-confirm" class="btn btn-primary btn-large">Print</button>
-        <button id="print-cancel" class="btn-link">Cancel</button>
+  <dialog id="print-dialog" class="dialog dialog-card">
+    <div class="overlay-title dialog-title">Print Game Sheet</div>
+    <div class="form-group print-form-group">
+      <label id="label-print-sections">Sections to Print</label>
+      <div id="print-sections-mode" class="segment-control" aria-labelledby="label-print-sections">
+        <button type="button" class="segment-btn" data-value="log">Game Log</button>
+        <button type="button" class="segment-btn active" data-value="both">Both</button>
+        <button type="button" class="segment-btn" data-value="stats">Stats</button>
       </div>
     </div>
-  </div>
+    <div class="form-group print-form-group" id="print-stats-format-group">
+      <label id="label-print-format">Stats Format</label>
+      <div id="print-stats-format" class="segment-control" aria-labelledby="label-print-format">
+        <button type="button" class="segment-btn active" data-value="cumulative">Cumulative</button>
+        <button type="button" class="segment-btn" data-value="per-period">Per Period</button>
+      </div>
+    </div>
+    <div class="dialog-actions">
+      <button id="print-confirm" class="btn btn-primary btn-large">Print</button>
+      <button id="print-cancel" class="btn-link">Cancel</button>
+    </div>
+  </dialog>
 
-  <!-- QR Code Full-Screen Overlay -->
-  <div id="qr-overlay" class="overlay qr-overlay">
+  <!-- QR Code Full-Screen Dialog -->
+  <dialog id="qr-dialog" class="dialog qr-dialog">
     <div class="qr-fullscreen-wrap">
       <div id="qr-svg-fullscreen" class="qr-fullscreen"></div>
     </div>
-  </div>
+  </dialog>
 
   <!-- Navigation -->
   <nav class="nav-bar">
@@ -178,9 +158,9 @@
   </section>
 
   <!-- ==================== EVENT MODAL ==================== -->
-  <div id="event-modal" class="event-modal">
-    <div class="event-modal-content" id="modal-content"></div>
-  </div>
+  <dialog id="event-modal" class="dialog event-modal">
+    <div class="event-modal-content" id="modal-content" tabindex="-1" autofocus></div>
+  </dialog>
 
   <!-- ==================== GAME SHEET SCREEN ==================== -->
   <section id="screen-sheet" class="screen">

--- a/js/app.js
+++ b/js/app.js
@@ -21,6 +21,7 @@ import { Setup } from './setup.js';
 import { Events } from './events.js';
 import { Sheet } from './sheet.js';
 import { Share } from './share.js';
+import { initDialog } from './dialog.js';
 
 
 // wplog — App Initialization + Screen Navigation
@@ -39,123 +40,65 @@ export const App = {
         // Footer "About" link
         document.getElementById("footer-about-link").addEventListener("click", (e) => {
             e.preventDefault();
-            document.getElementById("about-overlay").classList.add("visible");
+            document.getElementById("about-dialog").showModal();
         });
 
-        // About dismiss
-        document.getElementById("about-dismiss").addEventListener("click", () => {
-            document.getElementById("about-overlay").classList.remove("visible");
-        });
-        document.getElementById("about-overlay").addEventListener("click", (e) => {
-            if (e.target === e.currentTarget) {
-                document.getElementById("about-overlay").classList.remove("visible");
-            }
-        });
+        initDialog("about-dialog", { dismissId: "about-dismiss" });
 
-        // Privacy Policy overlay (opened from About dialog)
-        document.getElementById("about-privacy-link").addEventListener("click", async (e) => {
-            e.preventDefault();
-            document.getElementById("about-overlay").classList.remove("visible");
+        // Shared content dialog (privacy, license — stacks on top of About)
+        const contentDialog = document.getElementById("content-dialog");
+        const contentBody = document.getElementById("content-body");
+        const _contentCache = {};
 
-            // Load content from privacy.html (single source of truth)
-            const body = document.getElementById("privacy-body");
-            if (!body.innerHTML) {
+        const _openContentDialog = async (key, fetchFn) => {
+            if (!_contentCache[key]) {
                 try {
-                    const res = await fetch("privacy.html");
-                    const html = await res.text();
-                    const doc = new DOMParser().parseFromString(html, "text/html");
-                    body.innerHTML = doc.querySelector(".container").innerHTML;
-                    // Remove the back link — not needed in overlay
-                    const backLink = body.querySelector(".back-link");
-                    if (backLink) backLink.remove();
-                    // Remove the footer — not needed in overlay
-                    const footer = body.querySelector(".footer");
-                    if (footer) footer.remove();
+                    _contentCache[key] = await fetchFn();
                 } catch {
-                    body.innerHTML = "<p>Could not load privacy policy.</p>";
+                    _contentCache[key] = "<p>Could not load content.</p>";
                 }
             }
+            contentBody.innerHTML = _contentCache[key];
+            contentDialog.showModal();
+            contentDialog.scrollTop = 0;
+        };
 
-            document.getElementById("privacy-overlay").classList.add("visible");
-        });
-
-        document.getElementById("privacy-dismiss").addEventListener("click", () => {
-            document.getElementById("privacy-overlay").classList.remove("visible");
-            document.getElementById("about-overlay").classList.add("visible");
-        });
-        document.getElementById("privacy-overlay").addEventListener("click", (e) => {
-            if (e.target === e.currentTarget) {
-                document.getElementById("privacy-overlay").classList.remove("visible");
-                document.getElementById("about-overlay").classList.add("visible");
-            }
-        });
-
-        // License overlay (opened from About dialog)
-        document.getElementById("about-license-link").addEventListener("click", async (e) => {
+        document.getElementById("about-privacy-link").addEventListener("click", (e) => {
             e.preventDefault();
-            document.getElementById("about-overlay").classList.remove("visible");
-
-            // Load content from LICENSE (plain text)
-            const body = document.getElementById("license-body");
-            if (!body.innerHTML) {
-                try {
-                    const res = await fetch("LICENSE");
-                    const raw = await res.text();
-                    // Split into paragraphs (blank-line separated), join hard-wrapped lines
-                    const paragraphs = raw.trim().split(/\n\s*\n/).map(p =>
-                        p.split("\n").map(l => l.trimStart()).join(" ")
-                    );
-                    body.innerHTML = "<h1>License</h1>" +
-                        paragraphs.map(p => "<p>" + p.replace(/</g, "&lt;").replace(/>/g, "&gt;") + "</p>").join("");
-                } catch {
-                    body.innerHTML = "<p>Could not load license.</p>";
-                }
-            }
-
-            document.getElementById("license-overlay").classList.add("visible");
+            _openContentDialog("privacy", async () => {
+                const res = await fetch("privacy.html");
+                const html = await res.text();
+                const doc = new DOMParser().parseFromString(html, "text/html");
+                const container = doc.querySelector(".container");
+                const backLink = container.querySelector(".back-link");
+                if (backLink) backLink.remove();
+                const footer = container.querySelector(".footer");
+                if (footer) footer.remove();
+                return container.innerHTML;
+            });
         });
 
-        document.getElementById("license-dismiss").addEventListener("click", () => {
-            document.getElementById("license-overlay").classList.remove("visible");
-            document.getElementById("about-overlay").classList.add("visible");
-        });
-        document.getElementById("license-overlay").addEventListener("click", (e) => {
-            if (e.target === e.currentTarget) {
-                document.getElementById("license-overlay").classList.remove("visible");
-                document.getElementById("about-overlay").classList.add("visible");
-            }
+        document.getElementById("about-license-link").addEventListener("click", (e) => {
+            e.preventDefault();
+            _openContentDialog("license", async () => {
+                const res = await fetch("LICENSE");
+                const raw = await res.text();
+                const paragraphs = raw.trim().split(/\n\s*\n/).map(p =>
+                    p.split("\n").map(l => l.trimStart()).join(" ")
+                );
+                return "<h1>License</h1>" +
+                    paragraphs.map(p => "<p>" + p.replace(/</g, "&lt;").replace(/>/g, "&gt;") + "</p>").join("");
+            });
         });
 
-        // QR code full-screen overlay
+        initDialog("content-dialog", { dismissId: "content-dismiss" });
+
+        // QR code full-screen dialog
         document.querySelector(".qr-code").addEventListener("click", () => {
-            document.getElementById("qr-overlay").classList.add("visible");
+            document.getElementById("qr-dialog").showModal();
         });
-        document.getElementById("qr-overlay").addEventListener("click", () => {
-            document.getElementById("qr-overlay").classList.remove("visible");
-        });
-
-        // Universal Keyboard Overlay Router (innermost first)
-        document.addEventListener("keydown", (e) => {
-            if (e.key !== "Escape" && e.key !== "Enter") return;
-
-            const visibleOverlays = Array.from(document.querySelectorAll(".overlay.visible"));
-            if (visibleOverlays.length === 0) return;
-
-            e.preventDefault();
-            const activeOverlay = visibleOverlays.pop(); // Last in DOM structurally stacks on top
-
-            if (e.key === "Escape") {
-                // Priority 1: True cancel buttons
-                // Priority 2: Dismiss standard OK-only info overlays
-                const target = activeOverlay.querySelector(".btn-link, .btn-outline") || activeOverlay.querySelector(".btn-primary");
-                if (target) target.click();
-                else activeOverlay.classList.remove("visible"); // Fallback
-            } else if (e.key === "Enter") {
-                // Priority 1: Primary submission or confirm logic
-                const target = activeOverlay.querySelector(".btn-primary, #confirm-ok");
-                if (target && !target.disabled) target.click();
-                else if (!target) activeOverlay.classList.remove("visible"); // Fallback
-            }
+        document.getElementById("qr-dialog").addEventListener("click", () => {
+            document.getElementById("qr-dialog").close();
         });
 
         // Try to restore saved game

--- a/js/confirm.js
+++ b/js/confirm.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { initDialog } from './dialog.js';
+
 // wplog — Custom Confirmation Dialog
 // Replaces system confirm() which can be suppressed on mobile browsers.
 //
@@ -30,12 +32,16 @@ export const ConfirmDialog = {
     _resolve: null,
 
     init() {
-        document.getElementById("confirm-cancel").addEventListener("click", () => this._close(false));
+        const dialog = initDialog("confirm-dialog", {
+            dismissId: "confirm-cancel",
+            onClose: () => this._close(false),
+        });
         document.getElementById("confirm-ok").addEventListener("click", () => this._close(true));
 
-        // Backdrop click = cancel
-        document.getElementById("confirm-overlay").addEventListener("click", (e) => {
-            if (e.target === e.currentTarget) this._close(false);
+        // Native Escape = cancel
+        dialog.addEventListener("cancel", (e) => {
+            e.preventDefault();
+            this._close(false);
         });
     },
 
@@ -50,7 +56,7 @@ export const ConfirmDialog = {
         const cancelBtn = document.getElementById("confirm-cancel");
         cancelBtn.textContent = cancelLabel;
 
-        document.getElementById("confirm-overlay").classList.add("visible");
+        document.getElementById("confirm-dialog").showModal();
 
         return new Promise((resolve) => {
             this._resolve = resolve;
@@ -58,7 +64,8 @@ export const ConfirmDialog = {
     },
 
     _close(result) {
-        document.getElementById("confirm-overlay").classList.remove("visible");
+        const dialog = document.getElementById("confirm-dialog");
+        if (dialog.open) dialog.close();
         if (this._resolve) {
             this._resolve(result);
             this._resolve = null;

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026 Marko Milivojevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// wplog — Dialog Utilities
+
+/**
+ * Initialize a native <dialog> with standard close behaviors:
+ *   - Clicking the ::backdrop area closes the dialog
+ *   - An optional dismiss button closes the dialog
+ *   - An optional onClose callback replaces the default dialog.close()
+ *
+ * Returns the dialog element for further use.
+ */
+export function initDialog(id, { dismissId, onClose } = {}) {
+    const dialog = document.getElementById(id);
+
+    // Backdrop click = close
+    dialog.addEventListener("click", (e) => {
+        const rect = dialog.getBoundingClientRect();
+        if (e.clientX < rect.left || e.clientX > rect.right ||
+            e.clientY < rect.top || e.clientY > rect.bottom) {
+            onClose ? onClose() : dialog.close();
+        }
+    });
+
+    // Dismiss button
+    if (dismissId) {
+        document.getElementById(dismissId).addEventListener("click", () => {
+            onClose ? onClose() : dialog.close();
+        });
+    }
+
+    return dialog;
+}

--- a/js/events.js
+++ b/js/events.js
@@ -18,6 +18,7 @@ import { RULES } from './config.js';
 import { ConfirmDialog } from './confirm.js';
 import { Game } from './game.js';
 import { escapeHTML } from './sanitize.js';
+import { initDialog } from './dialog.js';
 import { Storage } from './storage.js';
 import { getMaxMinutes, parseTime, formatTimeDisplay } from './time.js';
 
@@ -83,12 +84,22 @@ export const Events = {
     // ── Modal Controls ──────────────────────────────────────
 
     _bindModalEvents() {
+        // Alert dialog (foul-out / load error popups)
+        initDialog("alert-dialog", { dismissId: "alert-dismiss" });
+
         // Cancel
         document.getElementById("event-modal-cancel").addEventListener("click", () => this._closeModal());
 
-        // Backdrop
-        document.getElementById("event-modal").addEventListener("click", (e) => {
-            if (e.target === e.currentTarget) this._closeModal();
+        // Backdrop — click outside modal content
+        const modal = document.getElementById("event-modal");
+        modal.addEventListener("click", (e) => {
+            if (e.target === modal) this._closeModal();
+        });
+
+        // Native Escape = cancel
+        modal.addEventListener("cancel", (e) => {
+            e.preventDefault();
+            this._closeModal();
         });
 
         // Team toggle
@@ -110,7 +121,7 @@ export const Events = {
 
         // Keyboard input — desktop support
         document.addEventListener("keydown", (e) => {
-            if (!document.getElementById("event-modal").classList.contains("visible")) return;
+            if (!document.getElementById("event-modal").open) return;
 
             const key = e.key;
 
@@ -175,23 +186,6 @@ export const Events = {
                     this._confirmEvent();
                 }
                 return;
-            }
-
-            // Escape = cancel
-            if (key === "Escape") {
-                e.preventDefault();
-                this._closeModal();
-                return;
-            }
-        });
-
-        // Keyboard: Escape/Enter to dismiss foul-out overlay
-        document.addEventListener("keydown", (e) => {
-            if (!document.getElementById("foulout-overlay").classList.contains("visible")) return;
-            if (document.getElementById("event-modal").classList.contains("visible")) return;
-            if (e.key === "Escape" || e.key === "Enter") {
-                e.preventDefault();
-                document.getElementById("foulout-overlay").classList.remove("visible");
             }
         });
     },
@@ -389,11 +383,12 @@ export const Events = {
         this._updateOkButton();
 
         // Show modal
-        document.getElementById("event-modal").classList.add("visible");
+        document.getElementById("event-modal").showModal();
     },
 
     _closeModal() {
-        document.getElementById("event-modal").classList.remove("visible");
+        const modal = document.getElementById("event-modal");
+        if (modal.open) modal.close();
         this._pendingEvent = null;
     },
 
@@ -750,16 +745,11 @@ export const Events = {
     // ── Notifications ───────────────────────────────────────
 
     _showFoulOutPopup(title, message) {
-        const overlay = document.getElementById("foulout-overlay");
-        document.getElementById("foulout-title").textContent = title;
-        document.getElementById("foulout-message").textContent = message;
-        overlay.classList.add("visible");
-
-        document.getElementById("foulout-dismiss").onclick = () => {
-            overlay.classList.remove("visible");
-        };
-
-        setTimeout(() => overlay.classList.remove("visible"), 5000);
+        const dialog = document.getElementById("alert-dialog");
+        document.getElementById("alert-title").textContent = title;
+        document.getElementById("alert-message").textContent = message;
+        dialog.showModal();
+        setTimeout(() => { if (dialog.open) dialog.close(); }, 5000);
     },
 
     _showToast(message, type = "info") {

--- a/js/setup.js
+++ b/js/setup.js
@@ -583,9 +583,9 @@ export const Setup = {
     },
 
     _showLoadError(message) {
-        const overlay = document.getElementById("foulout-overlay");
-        document.getElementById("foulout-title").textContent = "Load Failed";
-        document.getElementById("foulout-message").textContent = message;
-        overlay.classList.add("visible");
+        const dialog = document.getElementById("alert-dialog");
+        document.getElementById("alert-title").textContent = "Load Failed";
+        document.getElementById("alert-message").textContent = message;
+        dialog.showModal();
     },
 };

--- a/js/share.js
+++ b/js/share.js
@@ -16,6 +16,7 @@
 
 import { buildFilename, buildCSV } from './export.js';
 import { Sheet } from './sheet.js';
+import { initDialog } from './dialog.js';
 
 // wplog — Share / Export
 
@@ -55,14 +56,9 @@ export const Share = {
                 this._closeDownloadDialog();
             });
 
-            // Download cancel
-            document.getElementById("download-cancel").addEventListener("click", () => {
-                this._closeDownloadDialog();
-            });
-
-            // Download backdrop click = cancel
-            document.getElementById("download-overlay").addEventListener("click", (e) => {
-                if (e.target === e.currentTarget) this._closeDownloadDialog();
+            initDialog("download-dialog", {
+                dismissId: "download-cancel",
+                onClose: () => this._closeDownloadDialog(),
             });
 
             // Print UI Event Delegation
@@ -129,12 +125,9 @@ export const Share = {
             }, 50);
         });
 
-        document.getElementById("print-cancel").addEventListener("click", () => {
-            this._closePrintDialog();
-        });
-
-        document.getElementById("print-overlay").addEventListener("click", (e) => {
-            if (e.target === e.currentTarget) this._closePrintDialog();
+        initDialog("print-dialog", {
+            dismissId: "print-cancel",
+            onClose: () => this._closePrintDialog(),
         });
     },
 
@@ -152,11 +145,11 @@ export const Share = {
             }
         });
 
-        document.getElementById("print-overlay").classList.add("visible");
+        document.getElementById("print-dialog").showModal();
     },
 
     _closePrintDialog() {
-        document.getElementById("print-overlay").classList.remove("visible");
+        document.getElementById("print-dialog").close();
     },
 
 
@@ -171,13 +164,13 @@ export const Share = {
         document.getElementById("download-title").textContent = title;
         const input = document.getElementById("download-filename");
         input.value = buildFilename(this.game, ext);
-        document.getElementById("download-overlay").classList.add("visible");
+        document.getElementById("download-dialog").showModal();
         input.focus();
         input.select();
     },
 
     _closeDownloadDialog() {
-        document.getElementById("download-overlay").classList.remove("visible");
+        document.getElementById("download-dialog").close();
         this._pendingFormat = null;
     },
 


### PR DESCRIPTION
- Convert 9 overlays from custom div.overlay to native dialog with
  showModal()/close(), eliminating manual z-index, .visible toggling,
  and position:fixed stacking
- Create shared initDialog() utility in dialog.js for backdrop-click
  and dismiss-button wiring (used by 6 dialogs)
- Consolidate Privacy and License into single content-dialog with
  cached content fetching, stacking natively on top of About
- Remove centralized keyboard router (native dialog handles Escape)
- Compact event modal on mobile: fit-content height with numpad
  buttons capped at 72px for landscape aspect ratio
- Fix auto-focus: tabindex=-1 autofocus on content wrapper absorbs
  showModal() focus, preventing spurious focus rings
- Hide all dialogs in print CSS
- Remove dead CSS: .confirm-card, --overlay-bg in print
- Net -102 lines across existing files + 47-line new dialog.js
