### PR TITLE
fix: QR dialog display — use standard dialog infrastructure (#168)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1464,41 +1464,17 @@ select.form-input {
 }
 
 .qr-dialog {
-  max-width: none;
-  width: auto;
-  background: transparent;
-  padding: 24px;
-  cursor: pointer;
-  animation: none;
-}
-
-.qr-fullscreen-wrap {
-  width: 90%;
-  aspect-ratio: 1;
-  max-height: 90%;
   background: var(--surface-white);
   padding: 12px;
-  border-radius: var(--radius-lg);
-  box-sizing: border-box;
-}
-
-/* Desktop: match modal dialog sizing */
-@media (min-width: 900px) and (min-height: 700px) {
-  .qr-fullscreen-wrap {
-    width: 480px;
-    height: 480px;
-  }
+  width: min(90vw, 90vh, 480px);
+  aspect-ratio: 1;
+  cursor: pointer;
 }
 
 .qr-fullscreen {
   width: 100%;
-  height: auto;
+  height: 100%;
   display: block;
-}
-
-/* Force QR to always have high contrast over its white wrapper */
-.qr-fullscreen {
-  color: var(--text-on-light);
 }
 
 .qr-fullscreen svg {

--- a/index.html
+++ b/index.html
@@ -133,9 +133,7 @@
 
   <!-- QR Code Full-Screen Dialog -->
   <dialog id="qr-dialog" class="dialog qr-dialog">
-    <div class="qr-fullscreen-wrap">
-      <div id="qr-svg-fullscreen" class="qr-fullscreen"></div>
-    </div>
+    <div id="qr-svg-fullscreen" class="qr-fullscreen"></div>
   </dialog>
 
   <!-- Navigation -->

--- a/js/app.js
+++ b/js/app.js
@@ -93,13 +93,13 @@ export const App = {
 
         initDialog("content-dialog", { dismissId: "content-dismiss" });
 
-        // QR code full-screen dialog
+        // QR code full-screen dialog — click anywhere to dismiss
+        const qrDialog = document.getElementById("qr-dialog");
         document.querySelector(".qr-code").addEventListener("click", () => {
-            document.getElementById("qr-dialog").showModal();
+            qrDialog.showModal();
         });
-        document.getElementById("qr-dialog").addEventListener("click", () => {
-            document.getElementById("qr-dialog").close();
-        });
+        initDialog("qr-dialog");
+        qrDialog.addEventListener("click", () => qrDialog.close());
 
         // Try to restore saved game
         const saved = Storage.load();


### PR DESCRIPTION
- Remove custom QR dialog CSS (qr-fullscreen-wrap, desktop media query,
  transparent background, manual sizing)
- Reuse base .dialog centering, border-radius, shadow, animation
- Replace click-anywhere handler with initDialog + content click
- Simplify HTML: remove inner wrapper div
- Net -27 lines
