### PR TITLE
feat(UI): Implement Light Theme and refactor Help architecture (#171)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,8 @@ wplog/
 │   ├── live.html       # Live log screen content (score bar, event buttons, log)
 │   ├── modal.html      # Event modal content (time, cap, numpad)
 │   ├── sheet.html      # Game sheet container
-│   └── share.html      # Share screen content (QR code, print button)
+│   ├── share.html      # Share screen content (QR code, print button)
+│   └── help.html       # Help screen content (quick reference)
 ├── css/
 │   ├── style.css       # Dark-mode design system, mobile-first
 │   ├── print.css       # Print-only B&W styles for game sheet
@@ -65,12 +66,6 @@ wplog/
 │   ├── share.js        # Share/Print functionality
 │   ├── export.js       # Export utilities — filename, CSV builders (pure — no DOM)
 │   └── app.js          # App init + screen navigation + version display
-├── help.html           # Standalone help page (uses standalone.css)
-├── sw.js               # Service worker (offline caching, version-keyed cache)
-├── manifest.json       # PWA manifest (relative paths for GH Pages)
-├── .github/
-│   └── workflows/
-│       └── deploy.yml  # Release-triggered deploy to gh-pages (injects version)
 ├── .agents/
 │   ├── skills/
 │   │   └── branching/
@@ -151,9 +146,9 @@ These were explicitly discussed and agreed with the user:
 | **SW dev vs prod** | Service worker uses network-first strategy in dev mode (no stale cache issues) and cache-first in production (offline reliability). |
 | **QR code sharing** | Single SVG (`img/qr-wplog.svg`) with white modules on transparent background. CSS `filter: invert(1)` for high-contrast overlay. Share screen always accessible. |
 | **Share tab always active** | Share tab is always enabled. Print Game Sheet button is disabled when no game is active. |
-| **Help screen** | 5th nav tab (always enabled). Full screen section with concise quick-reference guide (~1 min read). Not a footer link or overlay — too undiscoverable. |
+| **Help screen** | 5th nav tab (always enabled). Full screen section with concise quick-reference guide (~1 min read). Loaded at boot alongside all other screen fragments. |
 | **innerHTML sanitization** | All user-supplied values (team names, cap numbers, Game #, location, etc.) MUST be escaped via `escapeHTML()` from `sanitize.js` before `innerHTML` interpolation. Config-driven data (event names/codes) and internally computed values are safe but should still be escaped where mixed with user data. |
-| **CSP meta tags** | `Content-Security-Policy` and `X-Content-Type-Options` meta tags in `<head>` of `index.html`, `privacy.html`, and `help.html`. No `'unsafe-inline'` for scripts — all scripts are external. `style-src` still allows `'unsafe-inline'` for inline styles. |
+| **CSP meta tags** | `Content-Security-Policy` and `X-Content-Type-Options` meta tags in `<head>` of `index.html` and `privacy.html`. No `'unsafe-inline'` for scripts — all scripts are external. `style-src` still allows `'unsafe-inline'` for inline styles. |
 | **No inline scripts** | All JavaScript is in external files. `index.html` uses `js/loader.js` (app shell loader) and `js/year.js` (copyright year). Standalone pages use `js/year.js`. This enables strict CSP without `'unsafe-inline'` for `script-src`. |
 | **localStorage validation** | `Storage.load()` validates parsed data shape (`rules` is string, `log` is array) before returning. Tampered/corrupt data is silently ignored. |
 | **Stats are separate from log** | Live view: stats interleaved in recent events with teal accent. Game sheet: stats filtered from Progress of Game, shown in separate Player Stats section. |
@@ -173,6 +168,8 @@ These were explicitly discussed and agreed with the user:
 ## Current State (as of 2026-03-31)
 
 ### What's Done ✅
+- Added specific explicit Light Theme toggle (System / Dark / Light) in Setup screen. Uses OS `prefers-color-scheme` tracking via `mathMedia` when set to `system` natively updating `data-theme` without repeating CSS.
+- Re-architected Theme toggle and Restart App controls into an adjacent `.inline-menu` container.
 - Dynamic 10+ minute game clock support natively scales Numpad limit/UI dash format between 3-digit `M:SS` and 4-digit `MM:SS` modes depending on rule set, expanding config boundaries up to 20-minute periods/halves.
 - Externalized application configuration (`config.json`): decoupled game rules, events, and stats taxonomies from hardcoded application logic using an asynchronous boot loader.
 - Replaced JS-based pagination logic with a clean, fully native CSS `@media print` pipeline.

--- a/css/print.css
+++ b/css/print.css
@@ -147,12 +147,12 @@
     display: none !important;
   }
 
-  .stats-toggle-link:not(.active),
-  .stats-toggle-sep {
+  .inline-toggle-link:not(.active),
+  .inline-toggle-sep {
     display: none !important;
   }
 
-  .stats-toggle-link.active {
+  .inline-toggle-link.active {
     color: #000000 !important;
   }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -108,6 +108,81 @@
   --transition: 150ms ease;
 }
 
+/* ── Light Theme Override ── */
+:root[data-theme="light"] {
+  /* Backgrounds */
+  --bg-primary: #f8fafc;
+  --bg-secondary: #ffffff;
+  --bg-card: #ffffff;
+  --bg-elevated: #f1f5f9;
+  --bg-input: #ffffff;
+
+  /* Text */
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #64748b;
+  --text-on-light: #111;
+
+  /* Accent */
+  --accent-blue: #2563eb;
+  --accent-blue-glow: rgba(37, 99, 235, 0.2);
+  --accent-indigo: #4f46e5;
+  --accent-indigo-light: #6366f1;
+
+  /* Teams */
+  --white-team: #0f172a;
+  --white-team-bg: #ffffff;
+  --white-team-glow: rgba(15, 23, 42, 0.08);
+  --dark-team: #ea580c;
+  --dark-team-bg: rgba(234, 88, 12, 0.08);
+  --dark-team-glow: rgba(234, 88, 12, 0.15);
+  --official-team-bg: rgba(100, 116, 139, 0.08);
+  --official-team-glow: rgba(100, 116, 139, 0.15);
+
+  /* Event colors */
+  --event-goal: #16a34a;
+  --event-goal-bg: rgba(22, 163, 74, 0.1);
+  --event-exclusion: #ea580c;
+  --event-exclusion-bg: rgba(234, 88, 12, 0.1);
+  --event-penalty: #ea580c;
+  --event-penalty-bg: rgba(234, 88, 12, 0.1);
+  --event-timeout: #2563eb;
+  --event-timeout-bg: rgba(37, 99, 235, 0.1);
+  --event-yellow: #ca8a04;
+  --event-yellow-bg: rgba(202, 138, 4, 0.1);
+  --event-red: #dc2626;
+  --event-red-bg: rgba(220, 38, 38, 0.1);
+  --event-stat: #0d9488;
+  --event-stat-bg: rgba(13, 148, 136, 0.1);
+
+  /* Status */
+  --danger: #dc2626;
+  --danger-bg: rgba(220, 38, 38, 0.1);
+  --danger-dark: #b91c1c;
+  --danger-darker: #991b1b;
+  --danger-glow: rgba(220, 38, 38, 0.3);
+  --danger-glow-hover: rgba(220, 38, 38, 0.5);
+  --warning-amber: #ea580c;
+  --warning-amber-dark: #c2410c;
+  --warning-glow: rgba(234, 88, 12, 0.3);
+  --warning-glow-hover: rgba(234, 88, 12, 0.5);
+  --success: #16a34a;
+
+  /* Borders & surfaces */
+  --border: rgba(15, 23, 42, 0.12);
+  --border-focus: rgba(37, 99, 235, 0.5);
+  --overlay-bg: rgba(15, 23, 42, 0.4);
+  --highlight: rgba(15, 23, 42, 0.05);
+  --highlight-hover: rgba(15, 23, 42, 0.08);
+  --surface-white: #ffffff;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.05);
+  --shadow-md: 0 4px 6px -1px rgba(15, 23, 42, 0.1), 0 2px 4px -1px rgba(15, 23, 42, 0.06);
+  --shadow-lg: 0 10px 15px -3px rgba(15, 23, 42, 0.1), 0 4px 6px -2px rgba(15, 23, 42, 0.05);
+  --shadow-glow: 0 0 12px var(--accent-blue-glow);
+}
+
 /* ============================
    Accessibility Utilities
    ============================ */
@@ -522,20 +597,13 @@ select.form-input {
   margin-top: 8px;
 }
 
-.hard-reset-link {
-  display: block;
+.inline-menu {
   text-align: center;
+  margin-top: 24px;
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-caps);
   font-size: 12px;
-  color: var(--text-secondary);
-  text-decoration: none;
-  margin-top: 12px;
-  padding: 4px;
-  cursor: pointer;
-  transition: color 0.15s;
-}
-
-.hard-reset-link:hover {
-  color: var(--danger);
 }
 
 /* ============================
@@ -1293,24 +1361,24 @@ select.form-input {
   text-align: left;
 }
 
-.stats-toggle-link {
+.inline-toggle-link {
   color: var(--text-muted);
   cursor: pointer;
   transition: color var(--transition);
 }
 
-.stats-toggle-link:hover {
+.inline-toggle-link:hover {
   color: var(--accent-blue);
   opacity: 0.8;
 }
 
-.stats-toggle-link.active {
+.inline-toggle-link.active {
   color: var(--accent-blue);
   font-weight: 700;
   pointer-events: none;
 }
 
-.stats-toggle-sep {
+.inline-toggle-sep {
   color: var(--text-muted);
   font-weight: 300;
 }

--- a/index.html
+++ b/index.html
@@ -22,7 +22,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <meta name="description" content="Water polo game log — log events poolside, produce official game sheets">
   <meta name="theme-color" content="#0a0e1a">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <title>wplog — Water Polo Game Log</title>
@@ -83,7 +84,8 @@
       </div>
       <div class="about-row">
         <span class="about-label">Author</span>
-        <span class="about-value"><a href="https://icemarkom.dev/" target="_blank" rel="noopener">Marko Milivojevic</a></span>
+        <span class="about-value"><a href="https://icemarkom.dev/" target="_blank" rel="noopener">Marko
+            Milivojevic</a></span>
       </div>
     </div>
     <p class="about-description">Log water polo game events poolside and produce official looking game sheets.</p>
@@ -172,16 +174,14 @@
 
   <!-- ==================== HELP SCREEN ==================== -->
   <section id="screen-help" class="screen">
-    <div class="screen-content">
-      <div id="help-content" class="fetched-content"></div>
-    </div>
+    <div class="screen-content" id="help-content"></div>
   </section>
 
+  <!-- ==================== APP FOOTER ==================== -->
   <footer class="app-footer">
     Copyright &copy; <span id="copy-year"></span> Marko Milivojevic &middot;
     <a href="https://github.com/icemarkom/wplog" target="_blank" rel="noopener">wplog</a>
-    <span id="app-version"></span> &middot;
-    <a href="#" id="footer-about-link">About</a>
+    <span id="app-version"></span>
   </footer>
   <script src="js/year.js" defer></script>
 

--- a/js/app.js
+++ b/js/app.js
@@ -34,14 +34,21 @@ export const App = {
         // Initialize confirm dialog
         ConfirmDialog.init();
 
+        // Load Theme
+        const applyTheme = () => {
+            const theme = localStorage.getItem("wplog_theme") || "dark";
+            if (theme === "system") {
+                const isLight = window.matchMedia("(prefers-color-scheme: light)").matches;
+                document.documentElement.setAttribute("data-theme", isLight ? "light" : "dark");
+            } else {
+                document.documentElement.setAttribute("data-theme", theme);
+            }
+        };
+        applyTheme();
+        window.matchMedia("(prefers-color-scheme: light)").addEventListener("change", applyTheme);
+
         // Display version
         this._initVersion();
-
-        // Footer "About" link
-        document.getElementById("footer-about-link").addEventListener("click", (e) => {
-            e.preventDefault();
-            document.getElementById("about-dialog").showModal();
-        });
 
         initDialog("about-dialog", { dismissId: "about-dismiss" });
 
@@ -128,6 +135,24 @@ export const App = {
                 Setup.updateForActiveGame(this.game);
             }
         });
+        // About Dialog (Setup Screen)
+        const setupAbout = document.getElementById("setup-about-link");
+        if (setupAbout) {
+            setupAbout.addEventListener("click", (e) => {
+                e.preventDefault();
+                document.getElementById("about-dialog").showModal();
+            });
+        }
+
+        // About Dialog (Help Screen)
+        const helpAbout = document.getElementById("help-about-link");
+        if (helpAbout) {
+            helpAbout.addEventListener("click", (e) => {
+                e.preventDefault();
+                document.getElementById("about-dialog").showModal();
+            });
+        }
+
 
         // Hard Reset — uses native confirm() so it works even when custom code is broken
         document.getElementById("setup-hard-reset").addEventListener("click", async (e) => {
@@ -166,24 +191,8 @@ export const App = {
             Share.init(this.game);
         });
 
-        document.getElementById("nav-help").addEventListener("click", async () => {
+        document.getElementById("nav-help").addEventListener("click", () => {
             this.showScreen("help");
-
-            // Load content from help.html (single source of truth)
-            const el = document.getElementById("help-content");
-            if (!el.innerHTML) {
-                try {
-                    const res = await fetch("help.html");
-                    const html = await res.text();
-                    const doc = new DOMParser().parseFromString(html, "text/html");
-                    el.innerHTML = doc.querySelector(".container").innerHTML;
-                    // Remove the footer — not needed in-app
-                    const footer = el.querySelector(".footer");
-                    if (footer) footer.remove();
-                } catch {
-                    el.innerHTML = "<p>Could not load help content.</p>";
-                }
-            }
         });
 
         // Intercept native print to adjust layout dynamically
@@ -293,6 +302,7 @@ export const App = {
         document.getElementById("nav-sheet").disabled = !hasGame;
     },
 
+
     // Show a screen and initialize its module (used for restore on reload)
     _showScreenWithInit(name) {
         switch (name) {
@@ -319,22 +329,6 @@ export const App = {
                 break;
             case "help":
                 this.showScreen("help");
-                // Load help content (same logic as nav-help click)
-                (async () => {
-                    const el = document.getElementById("help-content");
-                    if (!el.innerHTML) {
-                        try {
-                            const res = await fetch("help.html");
-                            const html = await res.text();
-                            const doc = new DOMParser().parseFromString(html, "text/html");
-                            el.innerHTML = doc.querySelector(".container").innerHTML;
-                            const footer = el.querySelector(".footer");
-                            if (footer) footer.remove();
-                        } catch {
-                            el.innerHTML = "<p>Could not load help content.</p>";
-                        }
-                    }
-                })();
                 break;
             case "live":
             default:

--- a/js/loader.js
+++ b/js/loader.js
@@ -29,6 +29,7 @@ import { loadConfig } from './config.js';
         { url: "screens/modal.html" + _cb, target: "modal-content" },
         { url: "screens/sheet.html" + _cb, target: "sheet-container" },
         { url: "screens/share.html" + _cb, target: "share-content" },
+        { url: "screens/help.html" + _cb, target: "help-content" },
     ];
     await Promise.all(screens.map(async ({ url, target }) => {
         const res = await fetch(url);

--- a/js/setup.js
+++ b/js/setup.js
@@ -60,6 +60,13 @@ export const Setup = {
             btn.classList.toggle("active", btn.dataset.value === "off");
         });
 
+        // Reset theme setting
+        const currentTheme = localStorage.getItem("wplog_theme") || "dark";
+        const themeInline = document.getElementById("setup-theme-inline");
+        themeInline.querySelectorAll(".inline-toggle-link").forEach((link) => {
+            link.classList.toggle("active", link.dataset.theme === currentTheme);
+        });
+
         // Reset post-regulation segmented control
         const prControl = document.getElementById("setup-post-regulation");
         prControl.classList.remove("disabled");
@@ -467,6 +474,25 @@ export const Setup = {
 
             timeControl.querySelectorAll(".segment-btn").forEach((b) => b.classList.remove("active"));
             btn.classList.add("active");
+        });
+
+        // Theme inline control
+        const themeInline = document.getElementById("setup-theme-inline");
+        themeInline.addEventListener("click", (e) => {
+            const link = e.target.closest(".inline-toggle-link");
+            if (!link) return;
+
+            themeInline.querySelectorAll(".inline-toggle-link").forEach((l) => l.classList.remove("active"));
+            link.classList.add("active");
+
+            const theme = link.dataset.theme;
+            localStorage.setItem("wplog_theme", theme);
+            if (theme === "system") {
+                const isLight = window.matchMedia("(prefers-color-scheme: light)").matches;
+                document.documentElement.setAttribute("data-theme", isLight ? "light" : "dark");
+            } else {
+                document.documentElement.setAttribute("data-theme", theme);
+            }
         });
     },
 

--- a/js/sheet.js
+++ b/js/sheet.js
@@ -36,11 +36,10 @@ export const Sheet = {
             container.innerHTML = "";
             renderScreen(game, this, container, isPrint);
             
-            // Re-bind inline toggle if on screen
             if (!this.isPrint) {
                 const toggle = container.querySelector("#sheet-stats-format-toggle");
                 if (toggle) {
-                    toggle.querySelectorAll(".stats-toggle-link").forEach(btn => {
+                    toggle.querySelectorAll(".inline-toggle-link").forEach(btn => {
                         btn.addEventListener("click", (e) => {
                             this.statsFormat = e.target.dataset.format;
                             this.render(game, false);
@@ -335,9 +334,9 @@ export const Sheet = {
         title.className = "sheet-section-title";
         title.innerHTML = `
           <span class="stats-inline-toggle" id="sheet-stats-format-toggle">
-            <span class="stats-toggle-link ${isCumulative ? 'active' : ''}" data-format="cumulative">CUMULATIVE</span>
-            <span class="stats-toggle-sep"> / </span>
-            <span class="stats-toggle-link ${!isCumulative ? 'active' : ''}" data-format="per-period">PER PERIOD</span>
+            <span class="inline-toggle-link ${isCumulative ? 'active' : ''}" data-format="cumulative">CUMULATIVE</span>
+            <span class="inline-toggle-sep"> / </span>
+            <span class="inline-toggle-link ${!isCumulative ? 'active' : ''}" data-format="per-period">PER PERIOD</span>
           </span>
           PLAYER STATS
         `;

--- a/screens/help.html
+++ b/screens/help.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <!--
  Copyright 2026 Marko Milivojevic
 
@@ -15,26 +14,6 @@
  limitations under the License.
 -->
 
-<html lang="en">
-
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Quick Reference Guide for wplog — Water Polo Game Log">
-  <meta name="theme-color" content="#0a0e1a">
-  <meta http-equiv="Content-Security-Policy"
-    content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;">
-  <meta http-equiv="X-Content-Type-Options" content="nosniff">
-  <meta name="referrer" content="strict-origin-when-cross-origin">
-  <title>Help — wplog</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="icon" href="img/favicon-32.png" type="image/png" sizes="32x32">
-  <link rel="stylesheet" href="css/style.css">
-</head>
-
-<body>
   <div class="container">
     <h1>Quick Reference</h1>
 
@@ -150,13 +129,9 @@
       </ul>
     </div>
 
-    <div class="footer">
-      Copyright &copy;
-      <span id="year"></span> Marko Milivojevic &middot;
-      <a href="https://github.com/icemarkom/wplog" target="_blank" rel="noopener">wplog</a>
+    <div class="inline-menu" style="margin-top: 48px; margin-bottom: 24px;">
+      <a id="help-about-link" class="inline-toggle-link" href="#" style="text-decoration: none;">About wplog</a>
+    </div>
+
     </div>
   </div>
-  <script src="js/year.js" defer></script>
-</body>
-
-</html>

--- a/screens/setup.html
+++ b/screens/setup.html
@@ -143,4 +143,16 @@
 <button id="setup-start-btn" class="btn btn-primary btn-large">Start Game</button>
 <button id="setup-load-btn" class="btn btn-primary btn-large">Load Game</button>
 <input type="file" id="setup-load-file" accept=".json" class="sr-only">
-<a id="setup-hard-reset" class="hard-reset-link" href="#">Restart App</a>
+
+<div class="inline-menu">
+  <div id="setup-theme-inline" style="margin-bottom: 16px;">
+    <span class="inline-toggle-link" data-theme="system">System</span> <span class="inline-toggle-sep">/</span>
+    <span class="inline-toggle-link active" data-theme="dark">Dark</span> <span class="inline-toggle-sep">/</span>
+    <span class="inline-toggle-link" data-theme="light">Light</span>
+  </div>
+  <div>
+    <a id="setup-about-link" class="inline-toggle-link" href="#" style="text-decoration: none;">About wplog</a>
+    <span class="inline-toggle-sep" style="margin: 0 12px;">|</span>
+    <a id="setup-hard-reset" class="inline-toggle-link" href="#" style="text-decoration: none;">Restart App</a>
+  </div>
+</div>

--- a/sw.js
+++ b/sw.js
@@ -49,8 +49,8 @@ const ASSETS = [
     "./screens/modal.html",
     "./screens/sheet.html",
     "./screens/share.html",
+    "./screens/help.html",
     "./privacy.html",
-    "./help.html",
     "./LICENSE",
     "./manifest.json",
 ];


### PR DESCRIPTION
- Added explicit toggle for System/Dark/Light theme in Setup screen using window.matchMedia for native detection without CSS redundance.
- Converted help.html to a dynamically loaded screens/help.html fragment to match the application shell pattern.
- Removed duplicated and lazy-loaded Help screen routing logic from js/app.js.
- Consolidated setup and theme link styling globally under the semantic .inline-toggle-link class.
