### PR TITLE
revert: remove hardware period sync from ClockEngine and Events

### DIFF
--- a/js/clock.js
+++ b/js/clock.js
@@ -28,61 +28,6 @@ export const ClockEngine = {
   _lastGameStr: null,
   _lastShotStr: null,
 
-  /**
-   * Map raw hardware period integer to wplog period key.
-   * Hardware encoding (game_state.c JSON field "period"):
-   *   1-4  = regulation quarters
-   *   5    = OT1, 6 = OT2, 7+ = further OT
-   *   <= 0 = non-playing state (break, half-time, unset)
-   * @returns {number|string|null} wplog period: 1-4 (number), "OT1", "OT2" ..., or null
-   */
-  getPeriod: function() {
-    const p = this.state.period;
-    if (p == null || p <= 0) return null;  // break / half / unset
-    if (p <= 4) return p;                  // regulation quarter 1-4
-    return 'OT' + (p - 4);                // 5->OT1, 6->OT2, 7->OT3 ...
-  },
-
-  /**
-   * Advance game.currentPeriod from the hardware period when it is ahead.
-   * Never reverts - safe for mid-game reconnect and break frames (period <= 0).
-   * Handles regulation (1-4) and OT (OT1, OT2, ...) auto-advance.
-   * Shootout ("SO") is wplog-internal and is never auto-advanced here.
-   * @param {Object} game - wplog game object
-   * @returns {boolean} true if currentPeriod was changed
-   */
-  applyPeriodToGame: function(game) {
-    if (!game) return false;
-    const hw = this.getPeriod();
-    if (hw == null) return false;
-
-    const cur = game.currentPeriod;
-
-    // Numeric regulation: advance if hardware is strictly ahead
-    if (typeof hw === 'number' && typeof cur === 'number') {
-      if (hw > cur) { game.currentPeriod = hw; return true; }
-      return false;
-    }
-
-    // Hardware reports OT, game is still in regulation -> advance to OT
-    if (typeof hw === 'string' && hw.startsWith('OT') && typeof cur === 'number') {
-      game.currentPeriod = hw;
-      return true;
-    }
-
-    // Both OT: advance if hardware OT number is strictly higher
-    if (typeof hw === 'string' && hw.startsWith('OT') &&
-        typeof cur === 'string' && cur.startsWith('OT')) {
-      const hwN = parseInt(hw.slice(2));
-      const curN = parseInt(cur.slice(2));
-      if (hwN > curN) { game.currentPeriod = hw; return true; }
-      return false;
-    }
-
-    // Game is in SO or hardware < current -> no change
-    return false;
-  },
-
   startFeed: function(url = '/events') {
     if (this.feed) return;
     this.feed = new EventSource(url);

--- a/js/events.js
+++ b/js/events.js
@@ -556,15 +556,8 @@ export const Events = {
         // Set title
         this._setModalTitle(eventDef);
 
-        // Period selector - prefer hardware period if available and valid
+        // Period selector
         this._selectedPeriod = this.game.currentPeriod;
-        const hwPeriod = ClockEngine.getPeriod();
-        if (hwPeriod != null) {
-            const available = this._getAvailablePeriods();
-            if (available.some(p => String(p) === String(hwPeriod))) {
-                this._selectedPeriod = hwPeriod;
-            }
-        }
         this._buildPeriodPills();
 
         // Reset inputs
@@ -1319,16 +1312,6 @@ export const Events = {
         // and reverts by deleting the End of Period event.
         const container = document.getElementById("period-tabs");
         container.innerHTML = "";
-    },
-
-    /**
-     * Public entry point for external callers to repaint the score bar.
-     * Called by settings.js after applyPeriodToGame() advances the period.
-     * No-ops when Events has not been initialized.
-     */
-    refreshScoreBar() {
-        if (!this.game) return;
-        this._updateScoreBar();
     },
 
     _updateScoreBar() {


### PR DESCRIPTION
Rolling back to baseline before re-implementing period sync.
Removes getPeriod(), applyPeriodToGame(), and refreshScoreBar()
from clock.js and events.js respectively. The core bug (startFeed
gated behind settings.html fetch) is fixed separately in
wpboard settings.js — not in wplog.
