### PR TITLE
fix: system theme default and anti-FOUC bootstrap (#232)

### DIFF
--- a/.agents/skills/branching/SKILL.md
+++ b/.agents/skills/branching/SKILL.md
@@ -11,13 +11,13 @@ description: >-
 
 ## Current state
 
-- **`main`** — stable, production-ready v2.x line (all v2.x releases deploy from here)
-- **`v3`** — long-lived integration branch for v3.0.0 features (branches from `main`, merges back when ready)
+- **`main`** — stable, production-ready v3.x line (all v3.x releases deploy from here)
+- **`v4`** — long-lived integration branch for v4.0.0 features (branches from `main`, merges back when ready)
 - **Live site** deploys from `gh-pages` via release tags on `main`
 
 ## Branch types
 
-### v2.x work (on `main`)
+### v3.x work (on `main`)
 
 Bug fixes and minor enhancements for the current production release:
 
@@ -26,55 +26,55 @@ Bug fixes and minor enhancements for the current production release:
 | Bug fix | `fix/<name>` | `main` | `main` |
 | Minor enhancement | `feature/<name>` | `main` | `main` |
 
-### v3 work (on `v3`)
+### v4 work (on `v4`)
 
-New features targeting the v3.0.0 release:
+New features targeting the v4.0.0 release:
 
 | Work type | Branch pattern | Base branch | Merge target |
 |---|---|---|---|
-| v3 feature | `feature/<name>` | `v3` | `v3` |
-| v3 fix | `fix/<name>` | `v3` | `v3` |
+| v4 feature | `feature/<name>` | `v4` | `v4` |
+| v4 fix | `fix/<name>` | `v4` | `v4` |
 
 Short-lived branch naming examples: `fix/missing-stat`, `feature/edit-in-place`, `feature/setup-redesign`.
 
 ## Start work
 
-Determine whether the work targets **v2.x** (main) or **v3** (v3):
+Determine whether the work targets **v3.x** (main) or **v4** (v4):
 
 ```sh
-# v2.x work
+# v3.x work
 git checkout main
 git pull origin main
 git checkout -b fix/<name>    # or feature/<name>
 
-# v3 work
-git checkout v3
-git pull origin v3
+# v4 work
+git checkout v4
+git pull origin v4
 git checkout -b feature/<name>    # or fix/<name>
 ```
 
-When done, use the **geronimo** workflow to commit, push, PR into the correct target branch (`main` or `v3`), merge, and delete the branch.
+When done, use the **geronimo** workflow to commit, push, PR into the correct target branch (`main` or `v4`), merge, and delete the branch.
 
-## Syncing v2.x hotfixes into v3
+## Syncing v3.x hotfixes into v4
 
-When a hotfix lands on `main` that v3 also needs:
+When a hotfix lands on `main` that v4 also needs:
 
 ```sh
-git checkout v3
-git merge main -m "Sync main into v3"
+git checkout v4
+git merge main -m "Sync main into v4"
 ```
 
 ## Ship a release
 
-- **v2.x**: Use the **kraken** workflow to tag and release from `main`.
-- **v3.0.0**: When v3 is complete, merge `v3` into `main`, then use **kraken** to tag and release.
+- **v3.x**: Use the **kraken** workflow to tag and release from `main`.
+- **v4.0.0**: When v4 is complete, merge `v4` into `main`, then use **kraken** to tag and release.
 
 ## Gotchas
 
 - **Never commit directly to `main`** — always use short-lived branches and PRs
 - **Geronimo on `main`** is an escape hatch (commit + push only, no PR) — not the norm
-- **`v3` is long-lived** — don't delete it until v3.0.0 ships
-- **Ask which train** — when starting work, confirm whether it targets v2.x or v3
+- **`v4` is long-lived** — don't delete it until v4.0.0 ships
+- **Ask which train** — when starting work, confirm whether it targets v3.x or v4
 
 ## Validation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,9 +174,10 @@ These were explicitly discussed and agreed with the user:
 
 ---
 
-## Current State (as of 2026-04-09)
+## Current State (as of 2026-04-20)
 
 ### What's Done ✅
+- System theme default + anti-FOUC bootstrap (#232): Default theme changed from `"dark"` to `"system"` (follows OS preference). New `js/theme.js` synchronous bootstrap script runs in `<head>` before first CSS paint, seeding `localStorage` on first visit and immediately resolving the OS preference — eliminating theme flash. `app.js` and `setup.js` read `localStorage` directly (no fallback needed). Single source of truth for default lives in `theme.js`. Branching skill updated to reflect `v4` as the long-lived integration branch.
 - Fixed Legacy Time Storage Validation (#224): Augmented `storage.js` backward-compatibility parsing logic via `RE_GAME_TIME` (`/^\d{1,2}:[0-5]\d(?::[0-5]\d)?$/`) to safely absorb and migrate `"00:00"` and `"HH:MM:SS"` string formats into runtime integer values during JSON hydration. Migrated standard `_logPeriodEnd()` payload execution explicitly from `time: "00:00"` string writes over to strict integer logic (`time: 0`) to prevent further export pollution.
 - Coaching staff caps in Add Name (#221): Enabled "HC" and "AC" coaching cap numbers within the Roster-only "Add Name" flow by bypassing the missing `eventDef` check, while strictly maintaining the explicit rejection of bare "B" inputs globally.
 - Added Roster Delete Button (#218): Injected a native `✕` action button gracefully aligned via `absolute` positioning into the final data cell of screen-rendered roster rows. Masked the delete click behind strict bounds interception (`e.stopPropagation()`) against the `.roster-edit-row` trigger, and validated the action using the standard `ConfirmDialog` overlay with dynamic player name referencing.

--- a/index.html
+++ b/index.html
@@ -30,6 +30,8 @@
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="img/favicon-32.png" type="image/png" sizes="32x32">
   <link rel="apple-touch-icon" href="img/favicon-192.png">
+  <!-- Theme bootstrap: runs synchronously before first paint to avoid flash -->
+  <script src="js/theme.js"></script>
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/print.css" media="print">
 </head>

--- a/js/app.js
+++ b/js/app.js
@@ -37,10 +37,12 @@ export const App = {
         ConfirmDialog.init();
 
         // Load Theme
+        // theme.js (sync, in <head>) already set data-theme before first paint.
+        // Re-apply here to wire the OS-change listener and handle any edge cases.
         const applyTheme = () => {
-            const theme = localStorage.getItem("wplog_theme") || "dark";
+            const theme = localStorage.getItem("wplog_theme");
             if (theme === "system") {
-                const isLight = window.matchMedia("(prefers-color-scheme: light)").matches;
+                const isLight = window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches;
                 document.documentElement.setAttribute("data-theme", isLight ? "light" : "dark");
             } else {
                 document.documentElement.setAttribute("data-theme", theme);

--- a/js/setup.js
+++ b/js/setup.js
@@ -67,7 +67,7 @@ export const Setup = {
         });
 
         // Reset theme setting
-        const currentTheme = localStorage.getItem("wplog_theme") || "dark";
+        const currentTheme = localStorage.getItem("wplog_theme");
         const themeInline = document.getElementById("setup-theme-inline");
         themeInline.querySelectorAll(".inline-toggle-link").forEach((link) => {
             link.classList.toggle("active", link.dataset.theme === currentTheme);

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026 Marko Milivojevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// wplog — Theme Bootstrap (synchronous, no imports)
+//
+// Loaded as a plain <script> in <head> (no defer, no type="module") so it
+// runs before the first CSS paint, preventing a flash of the wrong theme.
+//
+// Seeds localStorage with "system" on first visit so all later reads
+// (app.js, setup.js) always find a stored value and need no fallback.
+//
+// Fallback chain when theme is "system":
+//   OS prefers light  → "light"
+//   OS prefers dark   → "dark"
+//   No preference     → "dark"  (wplog design default)
+//   matchMedia absent → "dark"  (very old browsers)
+
+(function () {
+    if (!localStorage.getItem("wplog_theme")) {
+        localStorage.setItem("wplog_theme", "system");
+    }
+
+    var theme = localStorage.getItem("wplog_theme");
+    var resolved;
+
+    if (theme === "system") {
+        var isLight = window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches;
+        resolved = isLight ? "light" : "dark";
+    } else {
+        resolved = theme;
+    }
+
+    document.documentElement.setAttribute("data-theme", resolved);
+}());

--- a/screens/setup.html
+++ b/screens/setup.html
@@ -174,7 +174,7 @@
 <div class="inline-menu">
   <div id="setup-theme-inline">
     <span class="inline-toggle-link" data-theme="system">System</span> <span class="inline-toggle-sep">/</span>
-    <span class="inline-toggle-link active" data-theme="dark">Dark</span> <span class="inline-toggle-sep">/</span>
+    <span class="inline-toggle-link" data-theme="dark">Dark</span> <span class="inline-toggle-sep">/</span>
     <span class="inline-toggle-link" data-theme="light">Light</span>
   </div>
   <div>

--- a/sw.js
+++ b/sw.js
@@ -25,6 +25,7 @@ const ASSETS = [
     "./css/style.css",
     "./css/print.css",
     "./js/sanitize.js",
+    "./js/theme.js",
     "./js/loader.js",
     "./js/year.js",
     "./config.json",


### PR DESCRIPTION
- Add js/theme.js: synchronous script in <head> that seeds localStorage
  on first visit ('system') and sets data-theme before first CSS paint,
  eliminating theme flash on load
- Change default theme from 'dark' to 'system' (follows OS preference)
- app.js and setup.js read localStorage directly; no fallback needed
- Remove DEFAULT_THEME from config.js; single source of truth is theme.js
- Add js/theme.js to sw.js ASSETS for offline use
- Update branching SKILL.md: v3 -> v4 as long-lived integration branch
