### PR TITLE
fix: blank shot clock during intervals, on hardware blank, and when GT <= SC (#67, #68)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,12 @@ These were explicitly discussed and agreed with the user:
 
 ---
 
+## Current State (as of 2026-05-03)
+
+### What's Done ✅
+- Interval tracking in period display (#67): `_renderPeriod()` now maps hardware period values -1 and -2 to "BREAK" and "HALF" labels respectively, instead of silently skipping the update and leaving the display frozen at the last playing period. Period 0 / null is still treated as unset (no-op).
+- Shot clock blanking (#68): `_renderShotClock()` refactored with a single `shouldBlank` boolean covering three conditions: (1) interval frames (period <= 0), (2) hardware blank sentinel (shot >= 65535 / 0xFFFF), (3) GT <= SC - game clock at or below shot clock, making the shot clock irrelevant regardless of what hardware sends. All three conditions produce empty string (truly invisible element), not '--'.
+
 ## Current State (as of 2026-05-02)
 
 ### What's Done ✅

--- a/js/clock.js
+++ b/js/clock.js
@@ -125,7 +125,18 @@ export const ClockEngine = {
   _renderShotClock: function() {
     const el = document.getElementById('display-shot-clock');
     if (!el) return;
-    const str = formatDeviceClock(this.state.shot, { showSubseconds: true, isShotClock: true });
+
+    const { period, clock, shot } = this.state;
+
+    const shouldBlank =
+      period == null || period <= 0 ||                      // interval (break/half/unset)
+      shot == null   || shot >= 65535 ||                    // hardware blank sentinel
+      (clock != null && clock < 65535 && clock <= shot);   // GT <= SC
+
+    const str = shouldBlank
+      ? ''
+      : formatDeviceClock(shot, { showSubseconds: true, isShotClock: true });
+
     if (str !== this._lastShotStr) {
       el.textContent = str;
       this._lastShotStr = str;
@@ -134,8 +145,12 @@ export const ClockEngine = {
 
   _renderPeriod: function() {
     const p = this.state.period;
-    if (p == null || p <= 0) return;
-    const label = p <= 4 ? 'Q' + p : 'OT' + (p - 4);
+    if (p == null || p === 0) return;  // truly unset - leave display alone
+    let label;
+    if      (p === -2) label = 'HALF';
+    else if (p === -1) label = 'BREAK';
+    else if (p <= 4)   label = 'Q' + p;
+    else               label = 'OT' + (p - 4);
     if (label === this._lastPeriodStr) return;
     const el = document.getElementById('current-period');
     if (el) { el.textContent = label; this._lastPeriodStr = label; }


### PR DESCRIPTION
## Summary

Fixes two bugs in `ClockEngine` (`js/clock.js`):

### Issue #67 - Intervals not tracked

`_renderPeriod()` was returning early for any `period <= 0` frame, leaving the period display frozen at the last playing period label. Interval frames now map correctly:
- `period == -1` - BREAK (between quarters)
- `period == -2` - HALF (half time)
- `period == 0` / null - still treated as unset (no-op)

### Issue #68 - Shot clock not cleared

`_renderShotClock()` refactored with a single `shouldBlank` boolean:

1. **Interval frames** (`period <= 0`) - break or half time.
2. **Hardware blank sentinel** (`shot >= 65535`) - hardware explicitly blanking the shot clock.
3. **GT <= SC** - game clock at or below shot clock value; shot clock is irrelevant regardless of what hardware sends.

All three produce empty string (truly invisible), not `'--'`.

Closes #67. Closes #68.